### PR TITLE
Run docker compose with --renew-anon-modules (-V)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,14 +2,9 @@ FROM node:11
 WORKDIR /frontend
 COPY package.json yarn.lock ./
 RUN yarn install
+RUN mkdir -p /frontend/.cache /frontend/.parcel-cache
 VOLUME /frontend/node_modules
 VOLUME /frontend/.cache
 VOLUME /frontend/.parcel-cache
-
-# make sure that stale caches aren't used
-RUN rm -rf /frontend/node_modules/*
-RUN rm -rf /frontend/.cache/*
-RUN rm -rf /frontend/.parcel-cache/*
-
 RUN yarn run parcel --version
-CMD yarn start
+CMD sh -c 'if [ -z "$(ls -A /frontend/.parcel-cache)" ]; then yarn start; else echo "parcel cache not empty, run docker-compose up with -V (--renew-anon-volumes)"; fi'


### PR DESCRIPTION
Apparently docker-compose doesn't treat anonymous VOLUMEs the same way as docker does. The `-V` flag to up makes docker-compose respect the dockerfile semantics. References:
https://github.com/docker/compose/pull/5596
https://github.com/docker/compose/issues/4337