### PR TITLE
Use docker-compose nameless volumes for node_modules and caches

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,9 @@ services:
             - type: bind
               source: ./frontend
               target: /frontend
+            - /frontend/node_modules
+            - /frontend/.parcel-cache
+            - /frontend/.cache
         working_dir: /frontend
         ports:
             - 2345:2345

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,14 +2,5 @@ FROM node:11
 WORKDIR /frontend
 COPY package.json yarn.lock ./
 RUN yarn install
-VOLUME /frontend/node_modules
-VOLUME /frontend/.cache
-VOLUME /frontend/.parcel-cache
-
-# make sure that stale caches aren't used
-RUN rm -rf /frontend/node_modules/*
-RUN rm -rf /frontend/.cache/*
-RUN rm -rf /frontend/.parcel-cache/*
-
 RUN yarn run parcel --version
 CMD yarn start


### PR DESCRIPTION
These can be removed with

    docker-compose rm --stop --force -v dev-frontend