### PR TITLE
Feature/constraints

### DIFF
--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -171,7 +171,7 @@ class Individual(BaseModel):
     id = AutoField(primary_key=True, column_name="individual_id")
     herd = ForeignKeyField(Herd)
     name = CharField(50, null=True)
-    certificate = CharField(20, unique=True)
+    certificate = CharField(20, null=True)
     number = CharField(20)
     sex = CharField(15, null=True)
     birth_date = DateField(null=True)

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -122,7 +122,7 @@ class Herd(BaseModel):
     """
     id = AutoField(primary_key=True, column_name="herd_id")
     genebank = ForeignKeyField(Genebank)
-    herd = IntegerField(unique=True)
+    herd = IntegerField()
     name = TextField(null=True)
     name_privacy = CharField(15, null=True)
     physical_address = TextField(null=True)
@@ -141,6 +141,14 @@ class Herd(BaseModel):
     latitude = FloatField(null=True)
     longitude = FloatField(null=True)
     coordinates_privacy = CharField(15, null=True)
+
+    class Meta:  #pylint: disable=too-few-public-methods
+        """
+        Add a unique index to herd+genebank
+        """
+        indexes = (
+            (('herd', 'genebank'), True),
+        )
 
 
 class Colour(BaseModel):

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -184,14 +184,6 @@ class Individual(BaseModel):
     litter = IntegerField(null=True)
     notes = CharField(100, null=True)
 
-    class Meta:  #pylint: disable=too-few-public-methods
-        """
-        Add a unique index to number+genebank
-        """
-        indexes = (
-            (('number', 'herd'), True),
-        )
-
 
 class Weight(BaseModel):
     """


### PR DESCRIPTION
This PR corrects a couple of issues relating to constraints:

1. `herd.herd` can't be unique by itself. Herd numbers may and are duplicated between genebanks. Since herd numbers must be unique _within_ genebanks, change the constraint to instead cover both `herd.herd` and `herd.genebank_id`.

2. Remove the unique constraint on `individual.number`+`individual.herd_id`. This used to be a unique constraint on `individual.number`+`individual.genebank_id`, but since `herd.genebank_id` no longer exist, and the current constraint does not make sense, we should remove it.

3. Allow `individual.certificate` to be both `NULL` and non-unique.  For the same reasons we can't enforce uniqueness on `individual.number` (no `individual.genebank_id` field), we can't enforce uniqueness on `individual.certificate`.  Also, having a `NULL` certificate is valid, albeit not good. A fair few individuals have `NULL` certificates and are additionally annotated with this fact. I'm suggesting there should be some sort of data health check web page for the herd and genebank owners to review these cases (as well as cases with duplicate numbers).