### PR TITLE
Update node to 14.3 in dockerfiles

### DIFF
--- a/.docker/herdbook-dev
+++ b/.docker/herdbook-dev
@@ -1,5 +1,5 @@
 # React build stage
-FROM node:13 as build-stage
+FROM node:14.3 as build-stage
 
 COPY ./frontend /build/
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11
+FROM node:14.3
 WORKDIR /frontend
 COPY package.json yarn.lock ./
 RUN yarn install


### PR DESCRIPTION
This updates yarn which in turn gets rid of the error messages "the engine
'parcel' appears to be invalid".