### PR TITLE
Add specific colour codes for Mellerud

### DIFF
--- a/app/default_data.json
+++ b/app/default_data.json
@@ -179,6 +179,16 @@
    "id": 99,
    "name": "Allt annat",
    "comment": null
+  },
+  {
+   "id": 100,
+   "name": "Svart/vit",
+   "comment": "Svart/vit Melleruds-kanin"
+  },
+  {
+   "id": 101,
+   "name": "Albino",
+   "comment": "Albino Melleruds-kanin"
   }
  ]
 }

--- a/app/default_data.json
+++ b/app/default_data.json
@@ -1,194 +1,194 @@
 {
- "Colour": [
-  {
-   "id": 11,
-   "name": "Svart",
-   "comment": "Kaninen ska vara helsvart"
-  },
-  {
-   "id": 12,
-   "name": "Vit albino",
-   "comment": "Ska ha r\u00f6da \u00f6gon"
-  },
-  {
-   "id": 13,
-   "name": "Brun",
-   "comment": "Kan ha svarta inslag"
-  },
-  {
-   "id": 14,
-   "name": "Bl\u00e5",
-   "comment": "\u00c4ven buken ska vara bl\u00e5"
-  },
-  {
-   "id": 15,
-   "name": "Gulbrun med bl\u00e5gr\u00e5 mask (Isabella",
-   "comment": "\u00c4ven gul siames r\u00e4knas hit"
-  },
-  {
-   "id": 16,
-   "name": "Brun med m\u00f6rk mask (Madagaskar",
-   "comment": "\u00c4ven Thyringer r\u00e4knas hit"
-  },
-  {
-   "id": 17,
-   "name": "Ljusbeige med m\u00f6rk mask (Sallander",
-   "comment": "\u00c4ven siames r\u00e4kans hit"
-  },
-  {
-   "id": 18,
-   "name": "Vit med bl\u00e5 eller bruna \u00f6gon",
-   "comment": "Kan ha m\u00f6rkare \u00f6ron"
-  },
-  {
-   "id": 19,
-   "name": "Svartbrun med vita st\u00e4nk",
-   "comment": null
-  },
-  {
-   "id": 21,
-   "name": "J\u00e4rngr\u00e5",
-   "comment": "\u00c4ven j\u00e4rnbl\u00e5 och grafitgr\u00e5 r\u00e4knas hit"
-  },
-  {
-   "id": 22,
-   "name": "Hargr\u00e5 / viltf\u00e4rgad",
-   "comment": "Varierar, kan vara ljus till m\u00f6rk"
-  },
-  {
-   "id": 23,
-   "name": "Sn\u00f6hare",
-   "comment": "Vit med svart sl\u00f6ja"
-  },
-  {
-   "id": 24,
-   "name": "R\u00f6dgul eller orange",
-   "comment": "Inte klart \u00e5tskild fr\u00e5n 25"
-  },
-  {
-   "id": 25,
-   "name": "Gul (\u00e4v. gul mage och viltgul (ljus mage",
-   "comment": "Inte klart \u00e5tskild fr\u00e5n 24"
-  },
-  {
-   "id": 26,
-   "name": "Viltbl\u00e5 (bl\u00e5 med ljus mage och Pearl egern",
-   "comment": "Gr\u00e5brun med bl\u00e5tt skimmer"
-  },
-  {
-   "id": 27,
-   "name": "Gr\u00e5melerad (Chinchilla",
-   "comment": "\u00c4ven gr\u00e5 och bl\u00e5 chinchilla r\u00e4knas hit"
-  },
-  {
-   "id": 31,
-   "name": "Svartbrokig (vit med svarta tecken",
-   "comment": "\u00c4ven med j\u00e4rngr\u00e5 tecken r\u00e4knas hit"
-  },
-  {
-   "id": 32,
-   "name": "Bl\u00e5brokig (vit med bl\u00e5 tecken",
-   "comment": null
-  },
-  {
-   "id": 33,
-   "name": "Viltbrokig (vit med hargr\u00e5 tecken",
-   "comment": null
-  },
-  {
-   "id": 34,
-   "name": "Gulbrokig (vit med gula tecken",
-   "comment": "\u00c4ven orange eller r\u00f6da tecken"
-  },
-  {
-   "id": 35,
-   "name": "Madagaskarbrokig",
-   "comment": "Allts\u00e5 madagaskartecknad bottenf\u00e4rg"
-  },
-  {
-   "id": 36,
-   "name": "Tref\u00e4rgad (Tricolor",
-   "comment": "Oftast vit med svarta och gula tecken"
-  },
-  {
-   "id": 37,
-   "name": "Chinchillabrokig (vit med chinchillatecken",
-   "comment": "\u00c4ven bl\u00e5 chinchilla eller gr\u00e5 f\u00e4rg"
-  },
-  {
-   "id": 38,
-   "name": "Brunbrokig (vit med (m\u00f6rkbruna tecken",
-   "comment": null
-  },
-  {
-   "id": 39,
-   "name": "F\u00e4rgad med enstaka vita tecken (Wiener",
-   "comment": "Ofta vit bl\u00e4s eller vit tass"
-  },
-  {
-   "id": 41,
-   "name": "Gul-bl\u00e5 tigrerad (Japan",
-   "comment": null
-  },
-  {
-   "id": 42,
-   "name": "Gul-svart tigrerad (Japan",
-   "comment": null
-  },
-  {
-   "id": 43,
-   "name": "Vit-svart tigrerad (Japan",
-   "comment": null
-  },
-  {
-   "id": 44,
-   "name": "Svart med vita stickelh\u00e5r (Svensk p\u00e4ls",
-   "comment": "\u00c4ven med gr\u00e5 eller ljusbruna s-h\u00e5r"
-  },
-  {
-   "id": 45,
-   "name": "Bl\u00e5 med vi buk p\u00e5 s\u00e4rskilt s\u00e4tt",
-   "comment": "Blue & White, \u00e4ven otter"
-  },
-  {
-   "id": 46,
-   "name": "Vit-bl\u00e5 tigrerad (Japan",
-   "comment": null
-  },
-  {
-   "id": 49,
-   "name": "Japanteckning av annat slag",
-   "comment": "\u00c4ven Japanteckning av ok\u00e4nt slag"
-  },
-  {
-   "id": 51,
-   "name": "Rexp\u00e4lsade att alla f\u00e4rger och teckningar",
-   "comment": null
-  },
-  {
-   "id": 52,
-   "name": "Svart med brun buk p\u00e5 s\u00e4rskilt s\u00e4tt",
-   "comment": "Black & tan, \u00e4ven otter"
-  },
-  {
-   "id": 53,
-   "name": "Svart med vit buk p\u00e5 s\u00e4rskilt s\u00e4tt",
-   "comment": "Black & White, \u00e4ven otter"
-  },
-  {
-   "id": 99,
-   "name": "Allt annat",
-   "comment": null
-  },
-  {
-   "id": 100,
-   "name": "Svart/vit",
-   "comment": "Svart/vit Melleruds-kanin"
-  },
-  {
-   "id": 101,
-   "name": "Albino",
-   "comment": "Albino Melleruds-kanin"
-  }
- ]
+  "Colour": [
+    {
+      "id": 11,
+      "name": "Svart",
+      "comment": "Kaninen ska vara helsvart"
+    },
+    {
+      "id": 12,
+      "name": "Vit albino",
+      "comment": "Ska ha röda ögon"
+    },
+    {
+      "id": 13,
+      "name": "Brun",
+      "comment": "Kan ha svarta inslag"
+    },
+    {
+      "id": 14,
+      "name": "Blå",
+      "comment": "Även buken ska vara blå"
+    },
+    {
+      "id": 15,
+      "name": "Gulbrun med blågrå mask (Isabella",
+      "comment": "Även gul siames räknas hit"
+    },
+    {
+      "id": 16,
+      "name": "Brun med mörk mask (Madagaskar",
+      "comment": "Även Thyringer räknas hit"
+    },
+    {
+      "id": 17,
+      "name": "Ljusbeige med mörk mask (Sallander",
+      "comment": "Även siames räkans hit"
+    },
+    {
+      "id": 18,
+      "name": "Vit med blå eller bruna ögon",
+      "comment": "Kan ha mörkare öron"
+    },
+    {
+      "id": 19,
+      "name": "Svartbrun med vita stänk",
+      "comment": null
+    },
+    {
+      "id": 21,
+      "name": "Järngrå",
+      "comment": "Även järnblå och grafitgrå räknas hit"
+    },
+    {
+      "id": 22,
+      "name": "Hargrå / viltfärgad",
+      "comment": "Varierar, kan vara ljus till mörk"
+    },
+    {
+      "id": 23,
+      "name": "Snöhare",
+      "comment": "Vit med svart slöja"
+    },
+    {
+      "id": 24,
+      "name": "Rödgul eller orange",
+      "comment": "Inte klart åtskild från 25"
+    },
+    {
+      "id": 25,
+      "name": "Gul (äv. gul mage och viltgul (ljus mage",
+      "comment": "Inte klart åtskild från 24"
+    },
+    {
+      "id": 26,
+      "name": "Viltblå (blå med ljus mage och Pearl egern",
+      "comment": "Gråbrun med blått skimmer"
+    },
+    {
+      "id": 27,
+      "name": "Gråmelerad (Chinchilla",
+      "comment": "Även grå och blå chinchilla räknas hit"
+    },
+    {
+      "id": 31,
+      "name": "Svartbrokig (vit med svarta tecken",
+      "comment": "Även med järngrå tecken räknas hit"
+    },
+    {
+      "id": 32,
+      "name": "Blåbrokig (vit med blå tecken",
+      "comment": null
+    },
+    {
+      "id": 33,
+      "name": "Viltbrokig (vit med hargrå tecken",
+      "comment": null
+    },
+    {
+      "id": 34,
+      "name": "Gulbrokig (vit med gula tecken",
+      "comment": "Även orange eller röda tecken"
+    },
+    {
+      "id": 35,
+      "name": "Madagaskarbrokig",
+      "comment": "Alltså madagaskartecknad bottenfärg"
+    },
+    {
+      "id": 36,
+      "name": "Trefärgad (Tricolor",
+      "comment": "Oftast vit med svarta och gula tecken"
+    },
+    {
+      "id": 37,
+      "name": "Chinchillabrokig (vit med chinchillatecken",
+      "comment": "Även blå chinchilla eller grå färg"
+    },
+    {
+      "id": 38,
+      "name": "Brunbrokig (vit med (mörkbruna tecken",
+      "comment": null
+    },
+    {
+      "id": 39,
+      "name": "Färgad med enstaka vita tecken (Wiener",
+      "comment": "Ofta vit bläs eller vit tass"
+    },
+    {
+      "id": 41,
+      "name": "Gul-blå tigrerad (Japan",
+      "comment": null
+    },
+    {
+      "id": 42,
+      "name": "Gul-svart tigrerad (Japan",
+      "comment": null
+    },
+    {
+      "id": 43,
+      "name": "Vit-svart tigrerad (Japan",
+      "comment": null
+    },
+    {
+      "id": 44,
+      "name": "Svart med vita stickelhår (Svensk päls",
+      "comment": "Även med grå eller ljusbruna s-hår"
+    },
+    {
+      "id": 45,
+      "name": "Blå med vi buk på särskilt sätt",
+      "comment": "Blue & White, även otter"
+    },
+    {
+      "id": 46,
+      "name": "Vit-blå tigrerad (Japan",
+      "comment": null
+    },
+    {
+      "id": 49,
+      "name": "Japanteckning av annat slag",
+      "comment": "Även Japanteckning av okänt slag"
+    },
+    {
+      "id": 51,
+      "name": "Rexpälsade att alla färger och teckningar",
+      "comment": null
+    },
+    {
+      "id": 52,
+      "name": "Svart med brun buk på särskilt sätt",
+      "comment": "Black & tan, även otter"
+    },
+    {
+      "id": 53,
+      "name": "Svart med vit buk på särskilt sätt",
+      "comment": "Black & White, även otter"
+    },
+    {
+      "id": 99,
+      "name": "Allt annat",
+      "comment": null
+    },
+    {
+      "id": 100,
+      "name": "Svart/vit",
+      "comment": "Svart/vit Melleruds-kanin"
+    },
+    {
+      "id": 101,
+      "name": "Albino",
+      "comment": "Albino Melleruds-kanin"
+    }
+  ]
 }


### PR DESCRIPTION
Mellerud rabbits can only ever be black/white or albino.
Use colour codes 100 and 101 for these.