### PR TITLE
Use herd tracking to get herd for individuals

### DIFF
--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -357,7 +357,7 @@ class Individual(BaseModel):
         """
         data = super().as_dict()
         data["origin_herd"] = {"id": self.origin_herd.id, "name": self.origin_herd.herd_name}
-        data["herd"] = self.current_herd
+        data["herd"] = {"id": self.current_herd.id, "name": self.current_herd.herd_name}
         data["mother"] = (
             {"id": self.mother.id, "name": self.mother.name} if self.mother else None
         )

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -356,8 +356,8 @@ class Individual(BaseModel):
         the weight, colour, and bodyfat tables.
         """
         data = super().as_dict()
-        data["origin_herd"] = {"id": self.origin_herd.id, "name": self.origin_herd.herd_name}
-        data["herd"] = {"id": self.current_herd.id, "name": self.current_herd.herd_name}
+        data["origin_herd"] = {"id": self.origin_herd.id, "herd":  self.origin_herd.herd, "herd_name": self.origin_herd.herd_name}
+        data["herd"] = {"id": self.current_herd.id, "herd": self.current_herd.herd, "herd_name": self.current_herd.herd_name}
         data["mother"] = (
             {"id": self.mother.id, "name": self.mother.name} if self.mother else None
         )

--- a/frontend/individual.tsx
+++ b/frontend/individual.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import {Link} from "react-router-dom";
 
 import { get } from './communication';
+import { herdLabel } from '~data_context_global';
 
 /**
  * Shows information for a given individual in a herd
@@ -32,8 +33,8 @@ export function Individual({id}: {id: string}) {
             <dt>Dödsdatum</dt> <dd>{individual.death_date ?? '-'}</dd>
             <dt>Dödsanteckning</dt> <dd>{individual.death_note ?? '-'}</dd>
             <dt>Besättning</dt>
-            <Link to={`/herd/${individual.herd.id}`}>
-              <dd>{individual.herd.name ?? individual.herd.id}</dd>
+            <Link to={`/herd/${individual.herd.herd}`}>
+              <dd>{herdLabel(individual.herd)}</dd>
             </Link>
             <dt>Mor</dt>
             {individual.mother


### PR DESCRIPTION
I think that this fixes all instances where `herd` was used erroneously. I have renamed `herd` as `origin_herd` to avoid this mistake in the future, so you will have to run `ALTER TABLE individual RENAME herd TO origin_herd;` in the database before testing this.