### PR TITLE
Proxy from nginx to snowpack dev server only

### DIFF
--- a/.docker/main
+++ b/.docker/main
@@ -13,6 +13,7 @@ RUN cd /app/dist && ln -s . static
 
 COPY system/supervisord.conf /etc/
 COPY system/nginx.conf /etc/nginx/
+COPY system/herdbook.devel.nginx /etc/nginx/herdbook.devel
 COPY system/herdbook.standalone.nginx /etc/nginx/herdbook.standalone
 
 COPY system/entrypoint.sh /

--- a/README.md
+++ b/README.md
@@ -46,11 +46,9 @@ f62cebbc2e43        herdbook_main              "/bin/sh -c /entrypo…"   3 hour
 
 To access the local server deployed open this url https://localhost:8443 in your browser. You will need to configure the browser to allow self-signed localhost certificates. In Chrome, this can be done by accessing this property from the browser: `chrome://flags/#allow-insecure-localhost` and setting its vale to Enabled. In Firefox, when loading the url you can click on Advanced and  add the exception suggested from the browser. You can also use http://localhost:8080.
 
-The development server is at http://localhost:4242.
-
 To be able to login in the website and play with it you will need to create an user with admin privileges. This can be done by executing register_user.sh, providing your email and password:
 
 ```
-./register_user.sh 'user@domain.com', 'userpassword' 
+./register_user.sh 'user@domain.com', 'userpassword'
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,6 @@ services:
         volumes:
             - ./frontend:/app
             - /app/node_modules
-        ports:
-            - 4242:4242
     main:
         image: herdbook_main
         build:

--- a/frontend/snowpack.config.json
+++ b/frontend/snowpack.config.json
@@ -6,9 +6,6 @@
   "devOptions": {
     "port": 4242
   },
-  "proxy": {
-    "/api": "http://main:8080/api"
-  },
   "alias": {
     "@app": "./src"
   },

--- a/system/entrypoint.sh
+++ b/system/entrypoint.sh
@@ -27,6 +27,12 @@ chown www-data.www-data /code/*.pem
 chown www-data.www-data /tmp/database.ini
 chmod u+r /tmp/database.ini
 
-mv /etc/nginx/herdbook.standalone /etc/nginx/herdbook
+if getent hosts herdbook-frontend-devel >/dev/null; then
+    # Development mode
+    cp /etc/nginx/herdbook.devel /etc/nginx/herdbook
+else
+    # Standalone
+    cp /etc/nginx/herdbook.standalone /etc/nginx/herdbook
+fi
 
 supervisord -c /etc/supervisord.conf

--- a/system/herdbook.devel.nginx
+++ b/system/herdbook.devel.nginx
@@ -1,0 +1,22 @@
+    server {
+        listen 8443 ssl http2;
+        listen 8080;
+
+        ssl_certificate /code/cert.pem;
+        ssl_certificate_key /code/key.pem;
+        root /app/dist/;
+
+        location /api/ {
+                # There were issues using the wsgi transport for uwsgi,
+                # use its built in http server.
+                proxy_pass http://127.0.0.1:9090/api/;
+        }
+
+        location / {
+               proxy_pass http://herdbook-frontend-devel:4242;
+               proxy_http_version 1.1;
+               proxy_set_header Upgrade $http_upgrade;
+               proxy_set_header Connection "Upgrade";
+               proxy_set_header Host $host;
+        }
+    }


### PR DESCRIPTION
Changing to this setup by @pontus from before because the snowpack dev server doesn't proxy `UPDATE` properly.

Dev server is now at localhost:8443 and localhost:8080 again.