### PR TITLE
Feature/external dummy herds

### DIFF
--- a/frontend/src/user_context.tsx
+++ b/frontend/src/user_context.tsx
@@ -99,7 +99,7 @@ export function WithUserContext(props: {children: React.ReactNode}) {
       }
     }
     // id is a herd
-    else if (/^([a-zA-Z][0-9]+)$/.test(id)) {
+    else if (/^([a-zA-Z]X?[0-9]+)$/.test(id)) {
       const genebank = genebanks.find(genebank => genebank.herds.some(h => h.herd == id))
       // you can edit if you own the herd, or are manager of the genebank
       if (user.is_owner?.includes(id) || (genebank && user.is_manager?.includes(+genebank.id))) {

--- a/scripts/check-common.sh
+++ b/scripts/check-common.sh
@@ -8,5 +8,5 @@ echo 'Bad herd numbers (all genebanks):'
 psql --quiet <<-'END_SQL'
 	SELECT	herd
 	FROM	herd
-	WHERE	herd NOT SIMILAR TO '[GM][0-9]+';
+	WHERE	herd NOT (SIMILAR TO '[GM]X?[0-9]+';
 END_SQL

--- a/scripts/check-common.sh
+++ b/scripts/check-common.sh
@@ -8,5 +8,5 @@ echo 'Bad herd numbers (all genebanks):'
 psql --quiet <<-'END_SQL'
 	SELECT	herd
 	FROM	herd
-	WHERE	herd NOT (SIMILAR TO '[GM]X?[0-9]+';
+	WHERE	herd NOT SIMILAR TO '[GM]X?[0-9]+';
 END_SQL

--- a/scripts/load-gotland.sh
+++ b/scripts/load-gotland.sh
@@ -137,6 +137,12 @@ while [ "$year" -le 2020 ]; do
 	year=$(( year + 1 ))
 done | psql --quiet
 
+# Handle individual that have disappeared from this genebank (animals
+# sold to external herds).  For each individual with "ny G" equal to
+# "0", figure out the most recent tracking date.  Add tracking info
+# to the "GX1" herd at the last of December of the year
+# MAX(YEAR(most recent tracking date), YEAR(birth date)).
+
 # For the weight and body fat data, we run similar SQL as above, but
 # with different values for $column, and different ranges of values for
 # $year (etc.)

--- a/scripts/load-gotland.sh
+++ b/scripts/load-gotland.sh
@@ -47,6 +47,12 @@ psql --quiet <<-'END_SQL'
 	-- Genebank
 	INSERT INTO genebank (name) VALUES ('Gotlandskanin');
 
+	-- Dummy herd for individuals sold outside of the genebank
+	INSERT INTO herd (genebank_id, herd, herd_name)
+	SELECT	DISTINCT gb.genebank_id, 'GX1', 'Dummy herd (Gotland)'
+	FROM	genebank gb
+	WHERE	gb.name = 'Gotlandskanin';
+
 	-- Stub herd data
 	INSERT INTO herd (genebank_id, herd)
 	SELECT	DISTINCT gb.genebank_id, d."Genb"

--- a/scripts/load-gotland.sh
+++ b/scripts/load-gotland.sh
@@ -145,7 +145,7 @@ psql --quiet <<-'END_SQL'
 	INSERT INTO herd_tracking (herd_id, individual_id, herd_tracking_date)
 	SELECT	h.herd_id,
 		i.individual_id,
-		DATE(CONCAT_WS('-', DATE_PART('year', ht.herd_tracking_date), '12-31'))
+		MAKE_DATE(DATE_PART('year', ht.herd_tracking_date)::integer, 12, 31)
 	FROM	herd h
 	JOIN	individual i ON (true)
 	JOIN	herd_tracking ht ON (ht.individual_id = i.individual_id)

--- a/scripts/load-gotland.sh
+++ b/scripts/load-gotland.sh
@@ -49,7 +49,7 @@ psql --quiet <<-'END_SQL'
 
 	-- Dummy herd for individuals sold outside of the genebank
 	INSERT INTO herd (genebank_id, herd, herd_name)
-	SELECT	DISTINCT gb.genebank_id, 'GX1', 'Dummy herd (Gotland)'
+	SELECT	DISTINCT gb.genebank_id, 'GX1', 'Externa djur (Gotland)'
 	FROM	genebank gb
 	WHERE	gb.name = 'Gotlandskanin';
 

--- a/scripts/load-mellerud.sh
+++ b/scripts/load-mellerud.sh
@@ -50,7 +50,7 @@ psql --quiet <<-'END_SQL'
 
 	-- Dummy herd for individuals sold outside of the genebank
 	INSERT INTO herd (genebank_id, herd, herd_name)
-	SELECT	DISTINCT gb.genebank_id, 'MX1', 'Dummy herd (Mellerud)'
+	SELECT	DISTINCT gb.genebank_id, 'MX1', 'Externa djur (Mellerud)'
 	FROM	genebank gb
 	WHERE	gb.name = 'Mellerudskanin';
 

--- a/scripts/load-mellerud.sh
+++ b/scripts/load-mellerud.sh
@@ -48,6 +48,12 @@ psql --quiet <<-'END_SQL'
 	-- Genebank
 	INSERT INTO genebank (name) VALUES ('Mellerudskanin');
 
+	-- Dummy herd for individuals sold outside of the genebank
+	INSERT INTO herd (genebank_id, herd, herd_name)
+	SELECT	DISTINCT gb.genebank_id, 'MX1', 'Dummy herd (Mellerud)'
+	FROM	genebank gb
+	WHERE	gb.name = 'Mellerudskanin';
+
 	-- Stub herd data
 	INSERT INTO herd (genebank_id, herd)
 	SELECT	DISTINCT gb.genebank_id, d."Genb"


### PR DESCRIPTION
Adding dummy herds `GX1` and `MX1` for the two genebanks.  These will hold the animals sold outside of the genebanks (by means of entries added to the `herd_tracking` table).