### PR TITLE
Improve esbuild import.meta warning message

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -43,7 +43,4 @@ const Main =
 ReactDOM.render(Main, document.querySelector('#root'))
 
 // https://www.snowpack.dev/#hot-module-replacement
-if (import.meta.hot) {
-  import.meta.hot.accept();
-}
-
+import.meta?.hot?.accept() // Dan: OK to ignore esbuild warning on this line


### PR DESCRIPTION
Seems like there is no way to remove the warning message but it can be improved to this:
```
src/main.tsx:46:0: warning: "import.meta" is not available in the configured target environment and will be empty
import.meta?.hot?.accept() // Dan: OK to ignore esbuild warning on this line
~~~~~~~~~~~
1 warning
```