### PR TITLE
hotfix: correct bind mount for frontend rebuilding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
             cache_from:
               - ghcr.io/nbisweden/herdbook_frontend
         volumes:
-            - ./frontend:/app
+            - ./frontend:/home/node/app/
             - /app/node_modules
     main:
         image: herdbook_main


### PR DESCRIPTION
Fixes auto-rebulilding in the frontend by using the correct bind-mount path in docker-compose.