### PR TITLE
Add test for duplicate numbers

### DIFF
--- a/scripts/load-gotland.sh
+++ b/scripts/load-gotland.sh
@@ -2,7 +2,14 @@
 
 # Needs to be called by load.sh
 
-echo "Loading rabbits"
+# Checking for duplicate numbers before even attempting to load data.
+echo "Looking for duplicates"
+if csvcut -c 4 "$2" | sort | uniq -d | grep .; then
+	echo '!!! Duplicates found (see numbers above), aborting' >&2
+	exit 1
+fi
+
+echo 'Loading rabbits'
 
 csvsql  --db "$1" -I \
 	--tables g_data \

--- a/scripts/load-mellerud.sh
+++ b/scripts/load-mellerud.sh
@@ -2,7 +2,15 @@
 
 # Needs to be called by load.sh
 
-# read the csv into a temprary table called 'data'
+# Checking for duplicate numbers before even attempting to load data.
+echo "Looking for duplicates"
+if csvcut -c 5 "$2" | sort | uniq -d | grep .; then
+	echo '!!! Duplicates found (see numbers above), aborting' >&2
+	exit 1
+fi
+
+echo 'Loading rabbits'
+
 csvsql  --db "$1" -I \
 	--tables m_data \
 	--overwrite \


### PR DESCRIPTION
Check for duplicate numbers for both Gotland and Mellerud data sets.
If a duplicate number is found, issue a diagnostic message about this
and don't even attempt to load the data.

This should fix issue #225.