### PR TITLE
Bump jinja2 from known bad version

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,7 +4,7 @@ coverage==5.3
 Flask==1.1.2
 isort==4.3.21
 itsdangerous==1.1.0
-Jinja2==2.11.1
+Jinja2==2.11.3
 lazy-object-proxy==1.4.3
 MarkupSafe==1.1.1
 mccabe==0.6.1


### PR DESCRIPTION
Address https://github.com/NBISweden/theherdbook/security/dependabot/app/requirements.txt/jinja2/open