### PR TITLE
Various

### DIFF
--- a/scripts/dump_load_db.sh
+++ b/scripts/dump_load_db.sh
@@ -1,92 +1,113 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
-cd $(dirname $0)
+set -e
 
-# some config variables
-function path {
-  if command -v realpath >/dev/null
-  then
-    realpath $1
-  else
-    echo "$1"
-  fi
+scriptdir=$( dirname "$0" )
+
+ENV_FILE="$scriptdir/../.docker/database-variables.env"
+CONTAINER='herdbook-db'
+
+realpath () {
+	if command -v realpath >/dev/null; then
+		command realpath --relative-to="$PWD" "$1"
+	else
+		printf '%s\n' "$1"
+	fi
 }
 
-OUTPUT_DIR="$(path ${2:-../db_dumps})"
-BASE="db-dump"
-TIMESTAMP=$(date +"%Y-%m-%d_%H%M")
-ENV_FILE=../.docker/database-variables.env
-CONTAINER="herdbook-db"
-DUMP_FORMAT="tar"
+usage () {
+	cat <<-HELP
+	USAGE: $0 load [--clean] filename | dump [directory]
 
-if [[ ! "$1" =~ ^(load|dump)$ ]]
-then
-  cat << HELP
-USAGE: ./dump_load_db.sh [load [filename] | dump [directory]]
+	Sub-commands include
 
-Viable options are:
+	        load [--clean] filename
+	                                Load database dump from "filename".
+	                                The optional option "--clean" will drop
+	                                database objects before recreating them.
 
-      load <file> --clean       load database dump <file>. Optional flag --clean
-                                will drop database objects before recreating them
+	        dump [directory]
+	                                Create a dump file in "directory".
+	                                If no directory is given as an argument,
+	                                the dump file will be placed in
+	                                "$(realpath "$scriptdir/../db_dumps/")".
 
-      dump <directory>          create a dump file. If a directory is given as an
-                                argument the dump file will be placed there, else
-                                in projectroot/db_dumps/
+	         help
+	                                Show this help text.
+	HELP
 
-HELP
-  exit 0
-fi
+	exit 1
+}
 
 if [ "$( docker container inspect -f '{{.State.Status}}' ${CONTAINER} )" != "running" ]
 then
-  echo "Database container need to be running to perform backup operations"
-  exit 1
+	echo 'Database container need to be running to perform backup operations' >&2
+	exit 1
 fi
 
 # load database variables
-if [ ! -e "${ENV_FILE}" ]
-then
-  echo "Couldn't find env file '$ENV_FILE'." >&2
-  exit 1
-fi
-source ../.docker/database-variables.env
-if [[ -z "$POSTGRES_USER" || -z "$POSTGRES_DB" ]]
-then
-  echo "env file should contain variables POSTGRES_USER and POSTGRES_DB"
-  exit 1
+if [ ! -e "$ENV_FILE" ]; then
+	printf 'Could not find env file "%s"\n' "$ENV_FILE" >&2
+	exit 1
 fi
 
-FLAGS="-U $POSTGRES_USER -d $POSTGRES_DB"
+source "$scriptdir/../.docker/database-variables.env"
 
-if [[ "$1" == "load" ]]
-then
-  if [[ -z "$2" ]]
-  then
-    echo "Please specify database dump file"
-    exit 1
-  fi
-  DUMP_FILE=$(path $2)
-  if [ ! -e "${DUMP_FILE}" ]
-  then
-    echo "Couldn't find database dump file '$DUMP_FILE'." >&2
-    exit 1
-  fi
-  if [[ "$3" == "--clean" ]]
-  then
-    FLAGS="--clean $FLAGS"
-  fi
-  echo "Restoring database from dump file: ${DUMP_FILE}"
-  cat "$DUMP_FILE" | docker exec -i "${CONTAINER}" pg_restore $FLAGS
-
-else
-  if [[ "$1" == "dump" ]]
-  then
-    mkdir -p $OUTPUT_DIR
-    FILE="$OUTPUT_DIR/${BASE}_${TIMESTAMP}.sql.$DUMP_FORMAT"
-    echo "Creating database dump ${FILE}"
-    docker exec -i "${CONTAINER}" pg_dump \
-    $FLAGS \
-    --format="$DUMP_FORMAT" \
-    > "$FILE"
-  fi
+if [ -z "$POSTGRES_USER" ] || [ -z "$POSTGRES_DB" ]; then
+	echo 'env file should contain variables POSTGRES_USER and POSTGRES_DB'
+	exit 1
 fi
+
+FLAGS=(-U "$POSTGRES_USER" -d "$POSTGRES_DB")
+unset DUMP_FILE
+
+case $1 in
+	load)
+		shift
+		for arg do
+			case $arg in
+				--clean)
+					FLAGS+=(--clean)
+					;;
+				*)
+					DUMP_FILE=$arg
+			esac
+		done
+
+		if [ -z "$DUMP_FILE" ]; then
+			echo 'Please specify database dump' >&2
+			exit 1
+		fi
+
+		if [ ! -e "$DUMP_FILE" ]; then
+			printf 'Could not find database dump "%s"\n' "$DUMP_FILE" >&2
+			exit 1
+		fi
+
+		printf 'Restoring database from dump "%s"\n' "$DUMP_FILE"
+		docker exec -i "$CONTAINER" \
+			pg_restore "${FLAGS[@]}" <"$DUMP_FILE"
+		;;
+	dump)
+		OUTPUT_DIR="$(realpath "${2:-"$scriptdir/../db_dumps"}")"
+		BASE='db-dump'
+		printf -v TIMESTAMP '%(%Y-%m-%d_%H%M)T' -1
+		DUMP_FORMAT='tar'
+
+		printf -v DUMP_FILE '%s/%s_%s.sql.%s' \
+			"$OUTPUT_DIR" "$BASE" "$TIMESTAMP" "$DUMP_FORMAT"
+
+		mkdir -p "$OUTPUT_DIR"
+
+		printf 'Creating database dump "%s"\n' "$DUMP_FILE"
+		docker exec -i "$CONTAINER" \
+			pg_dump "${FLAGS[@]}" --format="$DUMP_FORMAT" >"$DUMP_FILE"
+		;;
+	''|help)
+		usage
+		;;
+	*)
+		printf 'Unknown sub-command "%s"\n' "$1" >&2
+		usage >&2
+		exit 1
+esac

--- a/scripts/dump_load_db.sh
+++ b/scripts/dump_load_db.sh
@@ -35,8 +35,6 @@ usage () {
 	         help
 	                                Show this help text.
 	HELP
-
-	exit 1
 }
 
 if [ "$( docker container inspect -f '{{.State.Status}}' ${CONTAINER} )" != "running" ]


### PR DESCRIPTION
Due to this morning's chatter around loading databases and setting up the project, I had a look at our database dump/restore script.

Changes:

* Rename `path` function `realpath` to overload the real `realpath` utility.
* Make `realpath` return pathnames relative to the current directory.
* Call `bash` using `env` (and set the `errexit` option with `set -e` instead).
* Create `help` function for help text output.
* Don't `cd` to script's directory (would cause unexpected path issue).
* Move output-related variables to "dump" section of code.
* Allow `--clean` option both before and after filename argument.
* Use `printf` for variable data output.
* Use array instead of string for `FLAGS`.
* Rearrange `if`-`then`-`else` body in `case ... esac` structure instead.
* Add `help` sub-command.
* Various cosmetic changes.