### PR TITLE
Fix logic for user selector

### DIFF
--- a/frontend/src/manage.tsx
+++ b/frontend/src/manage.tsx
@@ -129,7 +129,7 @@ export function Manage() {
     let targetOption: any = null;
     if (category == "user" && path == "new") {
       targetOption = { value: "new", label: "New User" };
-    } else if (category == "user" && isNaN(path)) {
+    } else if (category == "user" && !isNaN(+path)) {
       const targetUser = users.find((u: NameID) => u.id == +path);
       if (targetUser) {
         targetOption = { value: targetUser.id, label: userLabel(targetUser) };


### PR DESCRIPTION
Fixes logic to let user editor understand the selected user.

Fixes #244.

The user editor uses URL parts as `/manage/user/1` where 1 would be the selected user. Make sure to accept the user from that.