### PR TITLE
Issue certs with unique ids

### DIFF
--- a/.docker/main-load-db
+++ b/.docker/main-load-db
@@ -5,9 +5,9 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main 12" > /et
     apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y \
-    postgresql-client-12 xlsx2csv && \
+    postgresql-client-12 xlsx2csv swig python3-pykcs11 && \
     apt autoremove -y && \
-    rm -rf /var/lib/apt/lists/* 
+    rm -rf /var/lib/apt/lists/*
 
 COPY app/requirements.txt /code/requirements.txt
 

--- a/app/herdbook.py
+++ b/app/herdbook.py
@@ -532,7 +532,10 @@ def issue_certificate(i_number):
     if certificate_exists:
         return jsonify({"response": "Certificate already exists"}), 400
 
-    ind.update(**request.json, certificate=cert_number)
+    form = request.json
+    cert_number = ind["digital_certificate"]
+
+    ind.update(**form, certificate=cert_number)
     da.update_individual(ind, session.get("user_id", None))
 
     data = get_certificate_data(ind, user_id)
@@ -569,7 +572,7 @@ def preview_certificate(i_number):
     form = request.json
 
     data = get_certificate_data(ind, user_id)
-    data.update(**form)
+    data.update(**form, certificate=ind["digital_certificate"])
     pdf_bytes = get_certificate(data)
     return create_pdf_response(pdf_bytes=pdf_bytes, obj_name="preview.pdf")
 

--- a/app/herdbook.py
+++ b/app/herdbook.py
@@ -569,13 +569,13 @@ def preview_certificate(i_number):
     if ind is None:
         return jsonify({"response": "Individual not found"}), 404
 
+    data = get_certificate_data(ind, user_id)
+
     if request.method == "POST":
         form = request.json
-        data = get_certificate_data(ind, user_id)
         data.update(**form, certificate=ind["digital_certificate"])
         pdf_bytes = get_certificate(data)
     elif request.method == "GET":
-        data = get_certificate_data(ind, user_id)
         pdf_bytes = get_certificate(data)
 
     return create_pdf_response(pdf_bytes=pdf_bytes, obj_name="preview.pdf")

--- a/app/herdbook.py
+++ b/app/herdbook.py
@@ -558,7 +558,7 @@ def issue_certificate(i_number):
     return jsonify({"response": "Certificate could not be uploaded"}), 400
 
 
-@APP.route("/api/certificates/preview/<i_number>", methods=["POST"])
+@APP.route("/api/certificates/preview/<i_number>", methods=["POST", "GET"])
 @login_required
 def preview_certificate(i_number):
     """
@@ -569,11 +569,15 @@ def preview_certificate(i_number):
     if ind is None:
         return jsonify({"response": "Individual not found"}), 404
 
-    form = request.json
+    if request.method == "POST":
+        form = request.json
+        data = get_certificate_data(ind, user_id)
+        data.update(**form, certificate=ind["digital_certificate"])
+        pdf_bytes = get_certificate(data)
+    elif request.method == "GET":
+        data = get_certificate_data(ind, user_id)
+        pdf_bytes = get_certificate(data)
 
-    data = get_certificate_data(ind, user_id)
-    data.update(**form, certificate=ind["digital_certificate"])
-    pdf_bytes = get_certificate(data)
     return create_pdf_response(pdf_bytes=pdf_bytes, obj_name="preview.pdf")
 
 

--- a/app/herdbook.py
+++ b/app/herdbook.py
@@ -493,13 +493,14 @@ def update_certificate(i_number):
         return jsonify({"response": "Individual not found"}), 404
 
     certificate_exists = ind.get("certificate", None)
+    form = request.json
     uploaded = False
 
     try:
         present = check_certificate_s3(ind_number=ind["number"])
         if certificate_exists and present:
             data = get_certificate_data(ind, user_id)
-            data.update(**request.json)
+            data.update(**form)
             pdf_bytes = get_certificate(data)
             signed_data = sign_data(pdf_bytes)
             uploaded = upload_certificate(
@@ -531,8 +532,6 @@ def issue_certificate(i_number):
     if certificate_exists:
         return jsonify({"response": "Certificate already exists"}), 400
 
-    ##cert_number = str(random.randint(50001, 99999))
-    cert_number = "99999"
     ind.update(**request.json, certificate=cert_number)
     da.update_individual(ind, session.get("user_id", None))
 
@@ -567,8 +566,10 @@ def preview_certificate(i_number):
     if ind is None:
         return jsonify({"response": "Individual not found"}), 404
 
+    form = request.json
+
     data = get_certificate_data(ind, user_id)
-    data.update(**request.json)
+    data.update(**form)
     pdf_bytes = get_certificate(data)
     return create_pdf_response(pdf_bytes=pdf_bytes, obj_name="preview.pdf")
 

--- a/app/herdbook.py
+++ b/app/herdbook.py
@@ -535,8 +535,8 @@ def issue_certificate(i_number):
     form = request.json
     cert_number = ind["digital_certificate"]
 
-    ind.update(**form, certificate=cert_number)
-    da.update_individual(ind, session.get("user_id", None))
+    ind.certificate = cert_number
+    ind.save()
 
     data = get_certificate_data(ind, user_id)
     pdf_bytes = get_certificate(data)

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -1092,7 +1092,8 @@ def init():
         sh_bootstrap.save()
 
     ## Create sequence to allow unique ids for digital certificates
-    DATABASE.execute_sql('''CREATE SEQUENCE IF NOT EXISTS certificates_seq START WITH 100000 INCREMENT BY 1 MAXVALUE 199999 NO CYCLE''')
+    if type(DATABASE) == PostgresqlDatabase:
+        DATABASE.execute_sql('''CREATE SEQUENCE IF NOT EXISTS certificates_seq START WITH 100000 INCREMENT BY 1 MAXVALUE 199999 NO CYCLE''')
 
 
 def verify(try_init=True):

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -398,6 +398,8 @@ class Breeding(BaseModel):
 
         indexes = ((("mother", "father", "birth_date"), True),)
 
+## Create sequence to allow unique ids for digital certificates
+DATABASE.execute_sql('''CREATE SEQUENCE IF NOT EXISTS certificates_seq START WITH 100000 INCREMENT BY 1 MAXVALUE 199999 NO CYCLE''')
 
 class Individual(BaseModel):
     """
@@ -410,6 +412,7 @@ class Individual(BaseModel):
     origin_herd = ForeignKeyField(Herd)
     name = CharField(50, null=True)
     certificate = CharField(20, null=True)
+    digital_certificate = IntegerField(sequence="certificates_seq", unique=True)
     number = CharField(20)
     sex = CharField(15, null=True)
     color = ForeignKeyField(Color, null=True)

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -409,7 +409,7 @@ class Individual(BaseModel):
     origin_herd = ForeignKeyField(Herd)
     name = CharField(50, null=True)
     certificate = CharField(20, null=True)
-    digital_certificate = IntegerField(sequence="certificates_seq", unique=True)
+    digital_certificate = IntegerField(sequence="certificates_seq", unique=True, null=True)
     number = CharField(20)
     sex = CharField(15, null=True)
     color = ForeignKeyField(Color, null=True)

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -398,9 +398,6 @@ class Breeding(BaseModel):
 
         indexes = ((("mother", "father", "birth_date"), True),)
 
-## Create sequence to allow unique ids for digital certificates
-DATABASE.execute_sql('''CREATE SEQUENCE IF NOT EXISTS certificates_seq START WITH 100000 INCREMENT BY 1 MAXVALUE 199999 NO CYCLE''')
-
 class Individual(BaseModel):
     """
     Table for individual animals.
@@ -1093,6 +1090,9 @@ def init():
 
     with DATABASE.atomic():
         sh_bootstrap.save()
+
+    ## Create sequence to allow unique ids for digital certificates
+    DATABASE.execute_sql('''CREATE SEQUENCE IF NOT EXISTS certificates_seq START WITH 100000 INCREMENT BY 1 MAXVALUE 199999 NO CYCLE''')
 
 
 def verify(try_init=True):


### PR DESCRIPTION
- Used a SQL sequence for auto generation of unique ids within a series.
- Official certificate numbers become the digital id when issuing a digital certificate.

Closes #268 