### PR TITLE
Adding frontend for updating a certificate (incl. bugfix for issue and preview certificates)

### DIFF
--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -300,7 +300,6 @@ export function IndividualCertificate({
         }
       })
       .then((blob) => {
-        console.log("blob", blob);
         if (blob) {
           setCertificateUrl(window.URL.createObjectURL(blob));
           setShowSummary(false);

--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -594,7 +594,9 @@ export function IndividualCertificate({
                 issueCertificate(id, certificateData);
               }}
             >
-              {"Beställ certifikat"}
+              {action == "issue"
+                ? "Beställ certifikat"
+                : "Uppdatera certifikat"}
             </Button>
           </div>
         </>

--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -633,14 +633,20 @@ export function IndividualCertificate({
               color="primary"
               disabled={isUserGood ? false : true}
               onClick={() => {
-                action == "issue"
-                  ? issueCertificate(id, certificateData)
-                  : updateCertificate(id, certificateData);
+                switch (action) {
+                  case "issue":
+                    issueCertificate(id, certificateData);
+                    break;
+                  case "update":
+                    updateCertificate(id, certificateData);
+                }
               }}
             >
               {action == "issue"
                 ? "Beställ certifikat"
-                : "Uppdatera certifikat"}
+                : "update"
+                ? "Uppdatera certifikat"
+                : "Fortsätt"}
             </Button>
           </div>
         </>

--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -257,7 +257,7 @@ export function IndividualCertificate({
           throw new Error("Något gick fel.");
         }
       })
-      .then((blob: unknown) => {
+      .then((blob) => {
         if (blob) {
           setCertificateUrl(window.URL.createObjectURL(blob));
           setShowSummary(false);
@@ -305,8 +305,6 @@ export function IndividualCertificate({
           setShowSummary(false);
           setShowComplete(true);
         } else {
-          setShowSummary(false);
-          setShowComplete(true);
           throw new Error("Något gick fel.");
         }
       })

--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -221,6 +221,7 @@ export function IndividualCertificate({
       credentials: "same-origin",
       headers: {
         Accept: "application/octet-stream",
+        "Content-Type": "application/json",
       },
     })
       .then((res) => res.arrayBuffer())

--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -115,7 +115,13 @@ const useStyles = makeStyles({
   },
 });
 
-export function IndividualCertificate({ id }: { id: string }) {
+export function IndividualCertificate({
+  id,
+  action,
+}: {
+  id: string;
+  action: string;
+}) {
   const [individual, setIndividual] = React.useState(
     undefined as Individual | undefined
   );

--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -263,7 +263,7 @@ export function IndividualCertificate({
           setShowSummary(false);
           setShowComplete(true);
         } else {
-          throw new Error("Något gick fel.");
+          throw new Error("Något gick fel (det här borde inte hända).");
         }
       })
       .catch((error) => {

--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -285,11 +285,7 @@ export function IndividualCertificate({
       },
     })
       .then((res) => {
-        if (res.status === 400) {
-          throw new Error(
-            "Vi har tekniska problem. Certifikatet kunde inte uppdateras."
-          );
-        } else if (res.status === 404) {
+        if (res.status === 404) {
           throw new Error(
             "Kaninen eller dess certifikat kunde inte hittas i databasen."
           );

--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -250,7 +250,11 @@ export function IndividualCertificate({
           );
         } else if (res.status === 404) {
           throw new Error("Kaninen kunde inte hittas.");
-        } else res.blob();
+        } else if (res.status === 200) {
+          return res.blob();
+        } else {
+          throw new Error("Något gick fel.");
+        }
       })
       .then((blob: unknown) => {
         console.log(blob);
@@ -277,6 +281,7 @@ export function IndividualCertificate({
       credentials: "same-origin",
       headers: {
         Accept: "application/pdf",
+        "Content-Type": "application/json",
       },
     })
       .then((res) => {
@@ -285,10 +290,16 @@ export function IndividualCertificate({
             "Vi har tekniska problem. Certifikatet kunde inte uppdateras."
           );
         } else if (res.status === 404) {
-          throw new Error("Kaninen kunde inte hittas.");
-        } else res.blob();
+          throw new Error(
+            "Kaninen eller dess certifikat kunde inte hittas i databasen."
+          );
+        } else if (res.status === 200) {
+          return res.blob();
+        } else {
+          throw new Error("Något gick fel.");
+        }
       })
-      .then((blob: unknown) => {
+      .then((blob) => {
         console.log("blob", blob);
         if (blob) {
           setCertificateUrl(window.URL.createObjectURL(blob));

--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -225,7 +225,6 @@ export function IndividualCertificate({
     })
       .then((res) => res.arrayBuffer())
       .then((data) => {
-        console.log("cert", data);
         setPreviewUrl(data);
       })
       .catch((error) => {
@@ -241,6 +240,7 @@ export function IndividualCertificate({
       credentials: "same-origin",
       headers: {
         Accept: "application/pdf",
+        "Content-Type": "application/json",
       },
     })
       .then((res) => {
@@ -257,7 +257,6 @@ export function IndividualCertificate({
         }
       })
       .then((blob: unknown) => {
-        console.log(blob);
         if (blob) {
           setCertificateUrl(window.URL.createObjectURL(blob));
           setShowSummary(false);

--- a/frontend/src/individual_edit.tsx
+++ b/frontend/src/individual_edit.tsx
@@ -26,9 +26,11 @@ import {
   InputAdornment,
   TextField,
 } from "@material-ui/core";
-import { MuiPickersUtilsProvider } from "@material-ui/pickers";
+import {
+  MuiPickersUtilsProvider,
+  KeyboardDatePicker,
+} from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
-import { KeyboardDatePicker } from "@material-ui/pickers";
 import { useUserContext } from "@app/user_context";
 import { useDataContext } from "@app/data_context";
 import { Autocomplete } from "@material-ui/lab";
@@ -266,6 +268,8 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
       }
     );
   };
+
+  // jscpd:ignore-start
 
   return (
     <>
@@ -515,7 +519,7 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
                   color="primary"
                   onClick={() => {
                     updateField("weights", [
-                      ...individual.weights,
+                      ...individual?.weights,
                       { date: weightDate, weight: weight },
                     ]);
                   }}
@@ -592,7 +596,7 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
                   color="primary"
                   onClick={() => {
                     updateField("bodyfat", [
-                      ...individual.bodyfat,
+                      ...individual?.bodyfat,
                       { date: hullDate, bodyfat: bodyfat as BodyFat },
                     ]);
                   }}
@@ -620,4 +624,5 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
       )}
     </>
   );
+  // jscpd:ignore-end
 }

--- a/frontend/src/individual_view.tsx
+++ b/frontend/src/individual_view.tsx
@@ -212,7 +212,7 @@ export function IndividualView({ id }: { id: string }) {
                     popup(<IndividualCertificate id={id} action={"issue"} />)
                   }
                 >
-                  Skapa ny certifikat
+                  Skapa nytt certifikat
                 </Button>
               )}
               {user?.canEdit(id) && (

--- a/frontend/src/individual_view.tsx
+++ b/frontend/src/individual_view.tsx
@@ -208,9 +208,23 @@ export function IndividualView({ id }: { id: string }) {
                   className={style.editButton}
                   variant="contained"
                   color="primary"
-                  onClick={() => popup(<IndividualCertificate id={id} />)}
+                  onClick={() =>
+                    popup(<IndividualCertificate id={id} action={"issue"} />)
+                  }
                 >
-                  Beställ certifikat
+                  Skapa ny certifikat
+                </Button>
+              )}
+              {user?.canEdit(id) && (
+                <Button
+                  className={style.editButton}
+                  variant="contained"
+                  color="primary"
+                  onClick={() =>
+                    popup(<IndividualCertificate id={id} action={"update"} />)
+                  }
+                >
+                  Uppdatera certifikat
                 </Button>
               )}
               <div>


### PR DESCRIPTION
Two minor bugs were fixed:
- adding a content-type to the headers of the fetch request in `previewCertificate` 
- adding content-type, a return statement and more specific error handling in the fetch request in issueCertificate

Moreover, the user interface to update a certificate was added.