### PR TITLE
Functionality to download an existing certificate

### DIFF
--- a/frontend/src/certificate_download.tsx
+++ b/frontend/src/certificate_download.tsx
@@ -8,7 +8,7 @@ const useStyles = makeStyles({
   paneControls: {
     display: "flex",
     flexDirection: "row",
-    justifyContent: "space-between",
+    justifyContent: "space-evenly",
     padding: "20px 0",
   },
 });
@@ -24,6 +24,7 @@ export function CertificateDownload({
 
   return (
     <>
+      <h1>Du kan nu ladda ner eller öppna certifikatet.</h1>
       <div className={style.paneControls}>
         <a
           href={certUrl}

--- a/frontend/src/certificate_download.tsx
+++ b/frontend/src/certificate_download.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+import { Button, makeStyles } from "@material-ui/core";
+
+import { Individual } from "@app/data_context_global";
+
+const useStyles = makeStyles({
+  paneControls: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    padding: "20px 0",
+  },
+});
+
+export function CertificateDownload({
+  certUrl,
+  individual,
+}: {
+  certUrl: string;
+  individual: Individual;
+}) {
+  const style = useStyles();
+
+  return (
+    <>
+      <div className={style.paneControls}>
+        <a
+          href={certUrl}
+          download={individual.number}
+          rel="noopener noreferrer"
+        >
+          <Button variant="contained" color="primary">
+            {"Ladda ner"}
+          </Button>
+        </a>
+        <a target="_blank" href={certUrl} rel="noopener noreferrer">
+          <Button variant="contained" color="primary">
+            {"Öppna i ny flik"}
+          </Button>
+        </a>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -18,6 +18,7 @@ import { useUserContext } from "@app/user_context";
 import { useDataContext } from "@app/data_context";
 import { useMessageContext } from "@app/message_context";
 import { Individual, inputVariant, OptionType } from "@app/data_context_global";
+import { CertificateDownload } from "./certificate_download";
 
 //Styles for the form. A lot similar to the ones in individual_edit.
 //Find a different solution to avoid repetetive code.
@@ -442,27 +443,10 @@ export function IndividualCertificate({
         </>
       ) : individual && showComplete ? (
         <>
-          {action == "issue" ? (
-            <h1>Certifikatet är klart!</h1>
-          ) : (
-            <h1>Certifikatet uppdaterades!</h1>
-          )}
-          <div className={style.paneControls}>
-            <a
-              href={certificateUrl}
-              download={individual.number}
-              rel="noopener noreferrer"
-            >
-              <Button variant="contained" color="primary">
-                {"Ladda ner"}
-              </Button>
-            </a>
-            <a target="_blank" href={certificateUrl} rel="noopener noreferrer">
-              <Button variant="contained" color="primary">
-                {"Öppna i ny flik"}
-              </Button>
-            </a>
-          </div>
+          <CertificateDownload
+            certUrl={certificateUrl}
+            individual={individual}
+          />
         </>
       ) : (
         <></>

--- a/frontend/src/individual_view.tsx
+++ b/frontend/src/individual_view.tsx
@@ -4,7 +4,14 @@
  */
 import React from "react";
 import { Link } from "react-router-dom";
-import { Button, Tooltip } from "@material-ui/core";
+import {
+  Button,
+  ButtonGroup,
+  Menu,
+  MenuItem,
+  Tooltip,
+} from "@material-ui/core";
+import { ArrowForward } from "@material-ui/icons";
 import { makeStyles } from "@material-ui/core/styles";
 import { useMessageContext } from "@app/message_context";
 import { get } from "@app/communication";
@@ -64,6 +71,9 @@ const useStyles = makeStyles({
   editButton: {
     marginTop: "15px",
   },
+  icon: {
+    marginLeft: "0.5em",
+  },
 });
 
 /**
@@ -78,6 +88,8 @@ export function IndividualView({ id }: { id: string }) {
   );
   const [hasPaperCert, setHasPaperCert] = React.useState(false as boolean);
   const [hasDigitalCert, setHasDigitalCert] = React.useState(false as boolean);
+  // state to control the certificate menu button
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const { userMessage, popup } = useMessageContext();
 
   //checks if the individual has a certificate, and if yes whether it's a paper or digital one
@@ -92,6 +104,15 @@ export function IndividualView({ id }: { id: string }) {
       setHasPaperCert(false);
       setHasDigitalCert(true);
     }
+  };
+
+  // funtions to control the certificate menu button
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
   };
 
   const children: Individual[] = React.useMemo(() => {
@@ -245,33 +266,57 @@ export function IndividualView({ id }: { id: string }) {
                 </Button>
               )}
               {user?.canEdit(id) && hasDigitalCert && (
-                <Button
-                  className={style.editButton}
-                  variant="contained"
-                  color="primary"
-                  onClick={() =>
-                    popup(<IndividualCertificate id={id} action={"update"} />)
-                  }
-                >
-                  Uppdatera certifikat
-                </Button>
-              )}
-              {user?.canEdit(id) && hasDigitalCert && (
-                <Button
-                  className={style.editButton}
-                  variant="contained"
-                  color="primary"
-                  onClick={() =>
-                    popup(
-                      <CertificateVerification
-                        id={id}
-                        individual={individual}
-                      />
-                    )
-                  }
-                >
-                  Verifiera certifikat
-                </Button>
+                <>
+                  <Button
+                    aria-controls="simple-menu"
+                    aria-haspopup="true"
+                    variant="contained"
+                    color="primary"
+                    className={style.editButton}
+                    onClick={handleClick}
+                  >
+                    Certifikat{" "}
+                    <ArrowForward fontSize="small" className={style.icon} />
+                  </Button>
+                  <Menu
+                    id="simple-menu"
+                    anchorEl={anchorEl}
+                    keepMounted
+                    open={Boolean(anchorEl)}
+                    onClose={handleClose}
+                  >
+                    <MenuItem
+                      onClick={() => {
+                        handleClose();
+                      }}
+                    >
+                      Ladda ner
+                    </MenuItem>
+                    <MenuItem
+                      onClick={() => {
+                        handleClose();
+                        popup(
+                          <IndividualCertificate id={id} action={"update"} />
+                        );
+                      }}
+                    >
+                      Uppdatera
+                    </MenuItem>
+                    <MenuItem
+                      onClick={() => {
+                        handleClose();
+                        popup(
+                          <CertificateVerification
+                            id={id}
+                            individual={individual}
+                          />
+                        );
+                      }}
+                    >
+                      Verifiera
+                    </MenuItem>
+                  </Menu>
+                </>
               )}
               <div>
                 <h3>Besättningshistoria</h3>

--- a/frontend/src/individual_view.tsx
+++ b/frontend/src/individual_view.tsx
@@ -119,6 +119,7 @@ export function IndividualView({ id }: { id: string }) {
     setAnchorEl(null);
   };
 
+  // function to download an existing certificate
   const downloadCertificate = () => {
     fetch(`/api/certificates/issue/${id}`, {
       method: "GET",


### PR DESCRIPTION
Fix for one of Jonas comments.

- introducing a dropdown menu for different certificate actions
- creating a new component to download a certificate
- also replacing a piece of code in the issue/update component `individual_certificate` with the newly created download component.