### PR TITLE
Redirect insecure traffice to https

### DIFF
--- a/system/herdbook.standalone.nginx
+++ b/system/herdbook.standalone.nginx
@@ -1,7 +1,12 @@
 
+
+    server {
+        listen 8080;
+        return 301 https://$host$request_uri;
+    }
+
     server {
         listen 8443 ssl http2;
-        listen 8080;
 
         ssl_certificate /code/cert.pem;
         ssl_certificate_key /code/key.pem;


### PR DESCRIPTION
For production/standalone; redirect incoming requests without TLS to https.