### PR TITLE
Track newly added individuals in their herd

### DIFF
--- a/app/tests/database_test.py
+++ b/app/tests/database_test.py
@@ -11,7 +11,7 @@ isort:skip_file
 
 import os
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import utils.data_access as da
 
@@ -226,6 +226,6 @@ class DatabaseTest(unittest.TestCase):
                 herd=self.herds[2],
                 signature=self.manager,
                 individual=self.individuals[2],
-                herd_tracking_date=datetime.now(),
+                herd_tracking_date=datetime.now() - timedelta(days=30),
             )[0],
         ]

--- a/app/tests/test_data_access.py
+++ b/app/tests/test_data_access.py
@@ -267,6 +267,7 @@ class TestDataAccess(DatabaseTest):
             "admin_update": {
                 "number": self.individuals[0].number,
                 "certificate": "new-cert",
+                "birth_date": datetime.now(),
             },
             "unknown_color": {
                 "number": self.individuals[0].number,
@@ -276,7 +277,10 @@ class TestDataAccess(DatabaseTest):
                 "number": self.individuals[0].number,
                 "origin_herd": {"herd": "does-not-exist"},
             },
-            "valid": {"number": self.individuals[0].number},
+            "valid": {
+                "number": self.individuals[0].number,
+                "birth_date": datetime.now(),
+            },
         }
         self.assertRaises(
             PermissionError, da.form_to_individual, forms["valid"], self.specialist
@@ -307,6 +311,7 @@ class TestDataAccess(DatabaseTest):
                 "herd": self.herds[0].herd,
                 "origin_herd": {"herd": self.herds[1].herd},
                 "number": "H1-4",
+                "birth_date": datetime.now(),
             },
         }
         self.assertEqual(
@@ -347,6 +352,7 @@ class TestDataAccess(DatabaseTest):
                 "id": self.individuals[0].id,
                 "number": self.individuals[0].number,
                 "name": "new name",
+                "birth_date": datetime.now(),
             },
         }
         self.assertEqual(

--- a/app/tests/test_data_access.py
+++ b/app/tests/test_data_access.py
@@ -334,7 +334,7 @@ class TestDataAccess(DatabaseTest):
         self.assertEqual(status, {"status": "success", "message": "Individual Created"})
         ind = da.get_individual(forms["valid"]["number"], self.admin.uuid)
         self.assertIsNotNone(ind)
-        self.assertEqual(ind["herd"], {'id': 1, 'herd': 'H1', 'herd_name': 'herd1'})
+        self.assertEqual(ind["herd"], {"id": 1, "herd": "H1", "herd_name": "herd1"})
 
         # Make sure you cannot add rabbits with already existing numbers
         status = da.add_individual(forms["valid"], self.admin.uuid)

--- a/app/tests/test_data_access.py
+++ b/app/tests/test_data_access.py
@@ -267,7 +267,7 @@ class TestDataAccess(DatabaseTest):
             "admin_update": {
                 "number": self.individuals[0].number,
                 "certificate": "new-cert",
-                "birth_date": datetime.now(),
+                "birth_date": datetime.now() - timedelta(days=30),
             },
             "unknown_color": {
                 "number": self.individuals[0].number,
@@ -279,7 +279,7 @@ class TestDataAccess(DatabaseTest):
             },
             "valid": {
                 "number": self.individuals[0].number,
-                "birth_date": datetime.now(),
+                "birth_date": datetime.now() - timedelta(days=30),
             },
         }
         self.assertRaises(
@@ -311,7 +311,8 @@ class TestDataAccess(DatabaseTest):
                 "herd": self.herds[0].herd,
                 "origin_herd": {"herd": self.herds[1].herd},
                 "number": "H1-4",
-                "birth_date": datetime.now(),
+                "birth_date": datetime.now() - timedelta(days=30),
+                "selling_date": datetime.now() - timedelta(days=10),
             },
         }
         self.assertEqual(
@@ -331,9 +332,9 @@ class TestDataAccess(DatabaseTest):
 
         status = da.add_individual(forms["valid"], self.admin.uuid)
         self.assertEqual(status, {"status": "success", "message": "Individual Created"})
-        self.assertIsNotNone(
-            da.get_individual(forms["valid"]["number"], self.admin.uuid)
-        )
+        ind = da.get_individual(forms["valid"]["number"], self.admin.uuid)
+        self.assertIsNotNone(ind)
+        self.assertEqual(ind["herd"], {'id': 1, 'herd': 'H1', 'herd_name': 'herd1'})
 
         # Make sure you cannot add rabbits with already existing numbers
         status = da.add_individual(forms["valid"], self.admin.uuid)
@@ -352,7 +353,7 @@ class TestDataAccess(DatabaseTest):
                 "id": self.individuals[0].id,
                 "number": self.individuals[0].number,
                 "name": "new name",
-                "birth_date": datetime.now(),
+                "birth_date": datetime.now() - timedelta(days=30),
             },
         }
         self.assertEqual(

--- a/app/tests/test_endpoints.py
+++ b/app/tests/test_endpoints.py
@@ -13,7 +13,7 @@ isort:skip_file
 import base64
 import os
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import flask
 import requests
@@ -367,8 +367,14 @@ class TestEndpoints(FlaskTest):
         individual = self.individuals[0].number
         individual_2 = self.individuals[1].number
 
-        valid_issue_form = {"color_id": 3, "birth_date": datetime.now()}
-        valid_update_form = {"color_id": 2, "birth_date": datetime.now()}
+        valid_issue_form = {
+            "color_id": 3,
+            "birth_date": datetime.now() - timedelta(days=30),
+        }
+        valid_update_form = {
+            "color_id": 2,
+            "birth_date": datetime.now() - timedelta(days=30),
+        }
 
         mock = mock_s3()
         mock.start()

--- a/app/tests/test_endpoints.py
+++ b/app/tests/test_endpoints.py
@@ -367,12 +367,8 @@ class TestEndpoints(FlaskTest):
         individual = self.individuals[0].number
         individual_2 = self.individuals[1].number
 
-        valid_issue_form = {
-            "color_id": 3,
-        }
-        valid_update_form = {
-            "color_id": 2,
-        }
+        valid_issue_form = {"color_id": 3, "birth_date": datetime.now()}
+        valid_update_form = {"color_id": 2, "birth_date": datetime.now()}
 
         mock = mock_s3()
         mock.start()

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -876,7 +876,6 @@ def add_individual(form, user_uuid):
 
     individual.save()
 
-    setattr(individual, "herdtracking_set", True)
     update_herdtracking_values(
         individual=individual,
         herd=individual.origin_herd,
@@ -886,14 +885,13 @@ def add_individual(form, user_uuid):
 
 
 def update_herdtracking_values(individual, herd, user_signature):
-    if individual.herdtracking_set:
-        HerdTracking(
-            from_herd=herd,
-            herd=individual.origin_herd,
-            signature=user_signature,
-            individual=individual,
-            herd_tracking_date=datetime.now(),
-        ).save()
+    HerdTracking(
+        from_herd=herd,
+        herd=individual.origin_herd,
+        signature=user_signature,
+        individual=individual,
+        herd_tracking_date=datetime.now(),
+    ).save()
 
 
 def update_individual(form, user_uuid):

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -874,11 +874,26 @@ def add_individual(form, user_uuid):
     if "bodyfat" in form:
         update_bodyfat(individual, form["bodyfat"])
 
-    # TODO: also create herd tracking values
-
     individual.save()
+
+    setattr(individual, "herdtracking_set", True)
+    update_herdtracking_values(
+        individual=individual,
+        herd=individual.origin_herd,
+        user_signature=user,
+    )
     return {"status": "success", "message": "Individual Created"}
 
+
+def update_herdtracking_values(individual, herd, user_signature):
+    if individual.herdtracking_set:
+        HerdTracking(
+            from_herd=herd,
+            herd=individual.origin_herd,
+            signature=user_signature,
+            individual=individual,
+            herd_tracking_date=datetime.now(),
+        ).save()
 
 def update_individual(form, user_uuid):
     """

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -756,10 +756,6 @@ def form_to_individual(form, user=None):
     if "id" in form and form["id"] != individual.id:
         raise ValueError("Number can not be updated")
 
-    birth_date = form.get("birth_date", None)
-    if birth_date is None:
-        raise ValueError("Birth date must be present")
-
     can_manage = user and (
         user.is_admin
         or user.is_manager
@@ -868,6 +864,10 @@ def add_individual(form, user_uuid):
 
     if Individual.select().where(Individual.number == form["number"]).exists():
         return {"status": "error", "message": "Individual number already exists"}
+
+    birth_date = form.get("birth_date", None)
+    if birth_date is None:
+        return {"status": "error", "message": "Birth date must be defined"}
 
     try:
         individual = form_to_individual(form, user)

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -892,22 +892,23 @@ def add_individual(form, user_uuid):
     if selling_date is not None:
         update_herdtracking_values(
             individual=individual,
-            herd=individual.origin_herd,
+            herd=herd,
             user_signature=user,
-            tracking_date=form["selling_date"],
+            tracking_date=datetime.utcnow(),
         )
 
     return {"status": "success", "message": "Individual Created"}
 
 
 def update_herdtracking_values(individual, herd, user_signature, tracking_date):
-    HerdTracking(
-        from_herd=herd,
-        herd=individual.origin_herd,
-        signature=user_signature,
-        individual=individual,
-        herd_tracking_date=tracking_date,
-    ).save()
+    with DATABASE.atomic():
+        HerdTracking(
+            from_herd=individual.origin_herd,
+            herd=herd,
+            signature=user_signature,
+            individual=individual,
+            herd_tracking_date=tracking_date,
+        ).save()
 
 
 def update_individual(form, user_uuid):

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -756,6 +756,10 @@ def form_to_individual(form, user=None):
     if "id" in form and form["id"] != individual.id:
         raise ValueError("Number can not be updated")
 
+    birth_date = form.get("birth_date", None)
+    if birth_date is None:
+        raise ValueError("Birth date must be present")
+
     can_manage = user and (
         user.is_admin
         or user.is_manager
@@ -880,18 +884,29 @@ def add_individual(form, user_uuid):
         individual=individual,
         herd=individual.origin_herd,
         user_signature=user,
-        birth_date=form.get("birth_date", datetime.now()),
+        tracking_date=form["birth_date"],
     )
+
+    selling_date = form.get("selling_date", None)
+
+    if selling_date is not None:
+        update_herdtracking_values(
+            individual=individual,
+            herd=individual.origin_herd,
+            user_signature=user,
+            tracking_date=form["selling_date"],
+        )
+
     return {"status": "success", "message": "Individual Created"}
 
 
-def update_herdtracking_values(individual, herd, user_signature, birth_date):
+def update_herdtracking_values(individual, herd, user_signature, tracking_date):
     HerdTracking(
         from_herd=herd,
         herd=individual.origin_herd,
         signature=user_signature,
         individual=individual,
-        herd_tracking_date=birth_date,
+        herd_tracking_date=tracking_date,
     ).save()
 
 

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -895,6 +895,7 @@ def update_herdtracking_values(individual, herd, user_signature):
             herd_tracking_date=datetime.now(),
         ).save()
 
+
 def update_individual(form, user_uuid):
     """
     Updates an individual, identified by `form.number`, by the values in `form`,

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -880,17 +880,18 @@ def add_individual(form, user_uuid):
         individual=individual,
         herd=individual.origin_herd,
         user_signature=user,
+        birth_date=form.get("birth_date", datetime.now()),
     )
     return {"status": "success", "message": "Individual Created"}
 
 
-def update_herdtracking_values(individual, herd, user_signature):
+def update_herdtracking_values(individual, herd, user_signature, birth_date):
     HerdTracking(
         from_herd=herd,
         herd=individual.origin_herd,
         signature=user_signature,
         individual=individual,
-        herd_tracking_date=datetime.now(),
+        herd_tracking_date=birth_date,
     ).save()
 
 


### PR DESCRIPTION
Newly created individuals now are tracked within their current herd. This is done by adding a new entry to the herd tracking table.

We also have a new field called selling_date which is sent in the form optionally if the rabbit is directly sold and registered in a different herd.