### PR TITLE
Return breeding id from register breeding endpoint

### DIFF
--- a/app/tests/test_data_access.py
+++ b/app/tests/test_data_access.py
@@ -555,7 +555,8 @@ class TestDataAccess(DatabaseTest):
             {"status": "error", "message": "Date must be formatted as yyyy-mm-dd."},
         )
         self.assertEqual(
-            da.register_breeding(valid_form, self.admin.uuid), {"status": "success"}
+            da.register_breeding(valid_form, self.admin.uuid),
+            {"breeding_id": 5, "status": "success"},
         )
         self.assertEqual(
             da.register_breeding(valid_form, self.admin.uuid),

--- a/app/tests/test_endpoints.py
+++ b/app/tests/test_endpoints.py
@@ -218,7 +218,10 @@ class TestEndpoints(FlaskTest):
             # register a valid breeding event
             response = context.post("/api/breeding", json=valid_form)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.get_json(), {"status": "success"})
+            self.assertEqual(
+                response.get_json(),
+                {"breeding_id": 5, "status": "success"},
+            )
         # jscpd:ignore-end
 
     def test_register_birth(self):

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -1292,13 +1292,14 @@ def register_breeding(form, user_uuid):
         return {"status": "error", "message": "Breeding already registered"}
 
     with DATABASE.atomic():
-        Breeding(
+        breeding = Breeding(
             father=father,
             mother=mother,
             breed_date=breed_date,
             breed_notes=form.get("notes", None),
-        ).save()
-        return {"status": "success"}
+        )
+        breeding.save()
+        return {"status": "success", "breeding_id": breeding.id}
 
 
 def register_birth(form, user_uuid):


### PR DESCRIPTION
The register breeding event endpoint now returns the breeding id. This makes possible for our service to register birth events.