### PR TITLE
Feature sell rabbits

### DIFF
--- a/frontend/src/data_context_global.tsx
+++ b/frontend/src/data_context_global.tsx
@@ -38,7 +38,7 @@ export interface LimitedIndividual {
 }
 
 export interface Individual extends LimitedIndividual {
-  herd: HerdNameID;
+  herd: HerdNameID | string;
   origin_herd?: HerdNameID;
   genebank: string;
   certificate: string | null;

--- a/frontend/src/individual_add.tsx
+++ b/frontend/src/individual_add.tsx
@@ -105,9 +105,6 @@ export function IndividualAdd({
   const [currentGenebank, setCurrentGenebank] = React.useState(
     genebank ? genebank : (undefined as Genebank | undefined)
   );
-  const [herdOptions, setHerdOptions] = React.useState(
-    genebank ? genebank.herds : ([] as LimitedHerd[])
-  );
   const [success, setSuccess] = React.useState(false as boolean);
   // states to handle the Autocompletes rerendering
   const [herdKey, setHerdKey] = React.useState(0 as number);
@@ -496,7 +493,7 @@ export function IndividualAdd({
               </h2>
               <IndividualSellingform
                 individual={individual}
-                herdOptions={herdOptions}
+                herdOptions={genebank ? genebank.herds : []}
                 herdKey={herdKey}
                 onUpdateIndividual={handleUpdateIndividual}
               />

--- a/frontend/src/individual_add.tsx
+++ b/frontend/src/individual_add.tsx
@@ -28,7 +28,7 @@ import { useMessageContext } from "@app/message_context";
 import { get, post } from "@app/communication";
 import { useUserContext } from "./user_context";
 import { useDataContext } from "./data_context";
-import { IndividualSellingform } from "./individual_sellingform";
+import { IndividualSellingForm } from "./individual_sellingform";
 
 const useStyles = makeStyles({
   paneControls: {
@@ -491,7 +491,7 @@ export function IndividualAdd({
               <h2 className={style.sellingTitle}>
                 Fyll i bara om kaninen har sålts
               </h2>
-              <IndividualSellingform
+              <IndividualSellingForm
                 individual={individual}
                 herdOptions={genebank ? genebank.herds : []}
                 herdKey={herdKey}

--- a/frontend/src/individual_add.tsx
+++ b/frontend/src/individual_add.tsx
@@ -28,6 +28,7 @@ import { useMessageContext } from "@app/message_context";
 import { get, post } from "@app/communication";
 import { useUserContext } from "./user_context";
 import { useDataContext } from "./data_context";
+import { IndividualSellingform } from "./individual_sellingform";
 
 const useStyles = makeStyles({
   paneControls: {
@@ -337,7 +338,7 @@ export function IndividualAdd({
     } = await post("/api/breeding", breedingData);
 
     if (breedingEvent.status == "success") {
-      return breedingEvent.breeding_id;
+      return breedingEvent;
     }
 
     const translate: Map<string, string> = new Map([
@@ -493,45 +494,12 @@ export function IndividualAdd({
               <h2 className={style.sellingTitle}>
                 Fyll i bara om kaninen har sålts
               </h2>
-              <Autocomplete
-                key={herdKey}
-                options={herdOptions}
-                value={individual.herd}
-                getOptionLabel={(option: LimitedHerd) => herdLabel(option)}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    label="Välj besättning"
-                    variant="outlined"
-                    margin="normal"
-                    helperText="Lämna tom om kaninen inte har sålts"
-                  />
-                )}
-                className={style.ancestorInput}
-                onChange={(event, newValue) => {
-                  newValue && handleUpdateIndividual("herd", newValue.herd);
-                }}
+              <IndividualSellingform
+                individual={individual}
+                herdOptions={herdOptions}
+                herdKey={herdKey}
+                onUpdateIndividual={handleUpdateIndividual}
               />
-              <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                <KeyboardDatePicker
-                  autoOk
-                  fullWidth={true}
-                  className={style.ancestorInput}
-                  variant="inline"
-                  inputVariant="outlined"
-                  label="Köpdatum"
-                  format="yyyy-MM-dd"
-                  value={individual.selling_date ?? null}
-                  helperText="Lämna tom om kaninen inte har sålts"
-                  InputLabelProps={{
-                    shrink: true,
-                  }}
-                  onChange={(event, newValue) => {
-                    newValue &&
-                      handleUpdateIndividual("selling_date", newValue);
-                  }}
-                />
-              </MuiPickersUtilsProvider>
             </>
           )}
         </div>

--- a/frontend/src/individual_sell.tsx
+++ b/frontend/src/individual_sell.tsx
@@ -8,22 +8,64 @@ export function IndividualSell({ individual }: { individual: Individual }) {
   const [genebank, setGenebank] = React.useState(
     undefined as Genebank | undefined
   );
+  const [individualForSale, setIndividualForSale] = React.useState(
+    individual as Individual
+  );
+  const [herdKey, setHerdKey] = React.useState(0 as number);
   const { genebanks } = useDataContext();
 
   React.useEffect(() => {
     const currentGenebank = genebanks.find((genebank) =>
       genebank.individuals.some((i) => i.number == individual.number)
     );
+
     setGenebank(currentGenebank);
   }, [individual]);
 
+  /**
+   * Updates a single field in `individual`.
+   *
+   * @param field field name to update
+   * @param value the new value of the field
+   */
+  const handleUpdateIndividual = <T extends keyof Individual>(
+    field: T,
+    value: Individual[T]
+  ) => {
+    individualForSale &&
+      setIndividualForSale({ ...individualForSale, [field]: value });
+  };
+
+  /*
+  delete the herd field from individualForSale to get the dropdown input for 
+  herd empty when component is rendered
+  */
+  React.useEffect(() => {
+    let currentIndividual = individualForSale;
+    delete currentIndividual.herd;
+    setIndividualForSale(currentIndividual);
+  }, []);
+
   return (
     <>
+      <h2>
+        Sälja {individual.name} {individual.number}
+      </h2>
+      <p>
+        Ange besättningen som individen ska flyttas till, samt ett datum för
+        flytten. Individen kommer tas bort från din besättning och läggas till i
+        besättningen du anger.
+      </p>
+      <p>
+        Observera att du då inte längre kan ändra informationen om individen.
+        Det går inte heller att utfärda eller uppdatera digitala certifikat för
+        individen när den har flyttats.
+      </p>
       <IndividualSellingform
-        individual={individual}
+        individual={individualForSale}
         herdOptions={genebank ? genebank.herds : []}
-        herdKey={3}
-        onUpdateIndividual={() => console.log(individual)}
+        herdKey={herdKey}
+        onUpdateIndividual={handleUpdateIndividual}
       />
     </>
   );

--- a/frontend/src/individual_sell.tsx
+++ b/frontend/src/individual_sell.tsx
@@ -44,6 +44,12 @@ const useStyles = makeStyles({
   },
 });
 
+interface LimitedIndividualForSale {
+  number: string;
+  herd: string;
+  selling_date: string;
+}
+
 export function IndividualSell({ individual }: { individual: Individual }) {
   const [genebank, setGenebank] = React.useState(
     undefined as Genebank | undefined
@@ -110,7 +116,12 @@ export function IndividualSell({ individual }: { individual: Individual }) {
       userMessage("Fyll i ett köpdatum först.", "warning");
       return;
     }
-    patch("/api/individual", individualForSale).then((json) => {
+    const limitedIndividual: LimitedIndividualForSale = {
+      number: individualForSale.number,
+      herd: individualForSale.herd,
+      selling_date: individualForSale.selling_date,
+    };
+    patch("/api/individual", limitedIndividual).then((json) => {
       if (json.status == "success") {
         userMessage("Kaninen har flyttats till en annan besättning", "success");
         return;

--- a/frontend/src/individual_sell.tsx
+++ b/frontend/src/individual_sell.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 
+import { Button } from "@material-ui/core";
+
 import { Genebank, Individual } from "@app/data_context_global";
 import { useDataContext } from "@app/data_context";
 import { IndividualSellingform } from "./individual_sellingform";
+import { patch } from "./communication";
 
 export function IndividualSell({ individual }: { individual: Individual }) {
   const [genebank, setGenebank] = React.useState(
@@ -23,7 +26,7 @@ export function IndividualSell({ individual }: { individual: Individual }) {
   }, [individual]);
 
   /**
-   * Updates a single field in `individual`.
+   * Updates a single field in `individualForSale`.
    *
    * @param field field name to update
    * @param value the new value of the field
@@ -46,6 +49,12 @@ export function IndividualSell({ individual }: { individual: Individual }) {
     setIndividualForSale(currentIndividual);
   }, []);
 
+  const sellIndividual = () => {
+    patch("/api/individual", individualForSale).then((json) =>
+      console.log(json)
+    );
+  };
+
   return (
     <>
       <h2>
@@ -67,6 +76,9 @@ export function IndividualSell({ individual }: { individual: Individual }) {
         herdKey={herdKey}
         onUpdateIndividual={handleUpdateIndividual}
       />
+      <Button variant="contained" color="primary" onClick={sellIndividual}>
+        Sälj
+      </Button>
     </>
   );
 }

--- a/frontend/src/individual_sell.tsx
+++ b/frontend/src/individual_sell.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import { Genebank, Individual } from "@app/data_context_global";
+import { useDataContext } from "@app/data_context";
+import { IndividualSellingform } from "./individual_sellingform";
+
+export function IndividualSell({ individual }: { individual: Individual }) {
+  const [genebank, setGenebank] = React.useState(
+    undefined as Genebank | undefined
+  );
+  const { genebanks } = useDataContext();
+
+  React.useEffect(() => {
+    const currentGenebank = genebanks.find((genebank) =>
+      genebank.individuals.some((i) => i.number == individual.number)
+    );
+    setGenebank(currentGenebank);
+  }, [individual]);
+
+  return (
+    <>
+      <IndividualSellingform
+        individual={individual}
+        herdOptions={genebank ? genebank.herds : []}
+        herdKey={3}
+        onUpdateIndividual={() => console.log(individual)}
+      />
+    </>
+  );
+}

--- a/frontend/src/individual_sell.tsx
+++ b/frontend/src/individual_sell.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import {
+  Box,
   Button,
   Checkbox,
   FormLabel,
@@ -10,6 +11,7 @@ import {
   makeStyles,
   Typography,
 } from "@material-ui/core";
+import { CheckCircle } from "@material-ui/icons";
 
 import { Genebank, Individual } from "@app/data_context_global";
 import { useDataContext } from "@app/data_context";
@@ -42,6 +44,21 @@ const useStyles = makeStyles({
   buttonContainer: {
     display: "flex",
   },
+  responseBox: {
+    width: "100%",
+    maxWidth: "65em",
+    padding: "1em",
+    margin: "2em 0",
+  },
+  successIcon: {
+    fill: "#388e3c", // same as success.dark in the default theme
+    marginLeft: "0.5em",
+  },
+  boxTitle: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+  },
 });
 
 interface LimitedIndividualForSale {
@@ -59,6 +76,7 @@ export function IndividualSell({ individual }: { individual: Individual }) {
   );
   const [checked, setChecked] = React.useState(false as boolean);
   const [invalidSale, setInvalidSale] = React.useState(false as boolean);
+  const [success, setSuccess] = React.useState(false as boolean);
   const { genebanks } = useDataContext();
   const { userMessage } = useMessageContext();
   const style = useStyles();
@@ -123,7 +141,7 @@ export function IndividualSell({ individual }: { individual: Individual }) {
     };
     patch("/api/individual", limitedIndividual).then((json) => {
       if (json.status == "success") {
-        userMessage("Kaninen har flyttats till en annan besättning", "success");
+        setSuccess(true);
         return;
       }
       if (json.status == "error") {
@@ -136,55 +154,78 @@ export function IndividualSell({ individual }: { individual: Individual }) {
       <h2>
         Sälja {individual.name} {individual.number}
       </h2>
-      <div className={style.textContainer}>
-        <Typography variant="body1" className={style.infoText}>
-          Ange besättningen som individen ska flyttas till, samt ett datum för
-          flytten. Individen kommer tas bort från din besättning och läggas till
-          i besättningen du anger.
-        </Typography>
-        <Typography variant="body1" className={style.infoText}>
-          Observera att du då inte längre kan ändra informationen om individen.
-          Det går inte heller att utfärda eller uppdatera digitala certifikat
-          för individen när den har flyttats.
-        </Typography>
-      </div>
-      <div className={style.formContainer}>
-        <IndividualSellingForm
-          individual={individualForSale}
-          herdOptions={genebank ? genebank.herds : []}
-          onUpdateIndividual={handleUpdateIndividual}
-        />
-      </div>
-      <div>
-        <FormControl
-          required
-          error={error}
-          component="fieldset"
-          disabled={disabled}
-          className={style.checkContainer}
-        >
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={checked}
-                onChange={handleCheckbox}
-                color="primary"
-                inputProps={{ "aria-label": "primary checkbox" }}
-              />
-            }
-            label="Jag har tagit del av informationen och vill ta bort individen
+      {!success ? (
+        <>
+          <div className={style.textContainer}>
+            <Typography variant="body1" className={style.infoText}>
+              Ange besättningen som individen ska flyttas till, samt ett datum
+              för flytten. Individen kommer tas bort från din besättning och
+              läggas till i besättningen du anger.
+            </Typography>
+            <Typography variant="body1" className={style.infoText}>
+              Observera att du då inte längre kan ändra informationen om
+              individen. Det går inte heller att utfärda eller uppdatera
+              digitala certifikat för individen när den har flyttats.
+            </Typography>
+          </div>
+          <div className={style.formContainer}>
+            <IndividualSellingForm
+              individual={individualForSale}
+              herdOptions={genebank ? genebank.herds : []}
+              onUpdateIndividual={handleUpdateIndividual}
+            />
+          </div>
+          <div>
+            <FormControl
+              required
+              error={error}
+              component="fieldset"
+              disabled={disabled}
+              className={style.checkContainer}
+            >
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={checked}
+                    onChange={handleCheckbox}
+                    color="primary"
+                    inputProps={{ "aria-label": "primary checkbox" }}
+                  />
+                }
+                label="Jag har tagit del av informationen och vill ta bort individen
             från min besättning."
-          ></FormControlLabel>
-          <FormHelperText hidden={!error}>
-            Bekräfta att du tagit del av informationen.
-          </FormHelperText>
-        </FormControl>
-      </div>
-      <div className={style.buttonContainer}>
-        <Button variant="contained" color="primary" onClick={sellIndividual}>
-          Sälj
-        </Button>
-      </div>
+              ></FormControlLabel>
+              <FormHelperText hidden={!error}>
+                Bekräfta att du tagit del av informationen.
+              </FormHelperText>
+            </FormControl>
+          </div>
+          <div className={style.buttonContainer}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={sellIndividual}
+            >
+              Sälj
+            </Button>
+          </div>{" "}
+        </>
+      ) : (
+        <Box
+          border={3}
+          borderRadius={8}
+          borderColor="success.light"
+          className={style.responseBox}
+        >
+          <div className={style.boxTitle}>
+            <h2>Klart!</h2>
+            <CheckCircle className={style.successIcon} />
+          </div>
+          <p>
+            Individen har flyttats till besättning {individualForSale.herd}.
+          </p>
+        </Box>
+      )}
     </div>
   );
 }

--- a/frontend/src/individual_sell.tsx
+++ b/frontend/src/individual_sell.tsx
@@ -14,7 +14,7 @@ import {
 import { Genebank, Individual } from "@app/data_context_global";
 import { useDataContext } from "@app/data_context";
 import { useMessageContext } from "@app/message_context";
-import { IndividualSellingform } from "./individual_sellingform";
+import { IndividualSellingForm } from "./individual_sellingform";
 import { patch } from "./communication";
 
 const useStyles = makeStyles({
@@ -149,7 +149,7 @@ export function IndividualSell({ individual }: { individual: Individual }) {
         </Typography>
       </div>
       <div className={style.formContainer}>
-        <IndividualSellingform
+        <IndividualSellingForm
           individual={individualForSale}
           herdOptions={genebank ? genebank.herds : []}
           onUpdateIndividual={handleUpdateIndividual}

--- a/frontend/src/individual_sell.tsx
+++ b/frontend/src/individual_sell.tsx
@@ -1,11 +1,48 @@
 import React from "react";
 
-import { Button } from "@material-ui/core";
+import {
+  Button,
+  Checkbox,
+  FormLabel,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  makeStyles,
+  Typography,
+} from "@material-ui/core";
 
 import { Genebank, Individual } from "@app/data_context_global";
 import { useDataContext } from "@app/data_context";
+import { useMessageContext } from "@app/message_context";
 import { IndividualSellingform } from "./individual_sellingform";
 import { patch } from "./communication";
+
+const useStyles = makeStyles({
+  infoText: {
+    maxWidth: "40em",
+  },
+  checkContainer: {
+    margin: "1.5em 0",
+  },
+  popupContainer: {
+    maxWidth: "45em",
+    display: "flex",
+    flexDirection: "column",
+  },
+  textContainer: {
+    padding: "1.5em 0",
+    minHeight: "11em",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "space-between",
+  },
+  formContainer: {
+    maxWidth: "25em",
+  },
+  buttonContainer: {
+    display: "flex",
+  },
+});
 
 export function IndividualSell({ individual }: { individual: Individual }) {
   const [genebank, setGenebank] = React.useState(
@@ -14,8 +51,14 @@ export function IndividualSell({ individual }: { individual: Individual }) {
   const [individualForSale, setIndividualForSale] = React.useState(
     individual as Individual
   );
-  const [herdKey, setHerdKey] = React.useState(0 as number);
+  const [checked, setChecked] = React.useState(false as boolean);
+  const [invalidSale, setInvalidSale] = React.useState(false as boolean);
   const { genebanks } = useDataContext();
+  const { userMessage } = useMessageContext();
+  const style = useStyles();
+  const disabled: boolean =
+    !individualForSale.herd || !individualForSale.selling_date;
+  const error: boolean = invalidSale && !checked && !disabled;
 
   React.useEffect(() => {
     const currentGenebank = genebanks.find((genebank) =>
@@ -37,6 +80,7 @@ export function IndividualSell({ individual }: { individual: Individual }) {
   ) => {
     individualForSale &&
       setIndividualForSale({ ...individualForSale, [field]: value });
+    setInvalidSale(false);
   };
 
   /*
@@ -49,36 +93,87 @@ export function IndividualSell({ individual }: { individual: Individual }) {
     setIndividualForSale(currentIndividual);
   }, []);
 
+  const handleCheckbox = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(event.target.checked);
+  };
+
   const sellIndividual = () => {
-    patch("/api/individual", individualForSale).then((json) =>
-      console.log(json)
-    );
+    if (!checked) {
+      setInvalidSale(true);
+      return;
+    }
+    if (!individualForSale.herd) {
+      userMessage("Fyll i en besättning först", "warning");
+      return;
+    }
+    if (!individualForSale.selling_date) {
+      userMessage("Fyll i ett köpdatum först.", "warning");
+      return;
+    }
+    patch("/api/individual", individualForSale).then((json) => {
+      if (json.status == "success") {
+        userMessage("Kaninen har flyttats till en annan besättning", "success");
+        return;
+      }
+      if (json.status == "error") {
+      }
+    });
   };
 
   return (
-    <>
+    <div className={style.popupContainer}>
       <h2>
         Sälja {individual.name} {individual.number}
       </h2>
-      <p>
-        Ange besättningen som individen ska flyttas till, samt ett datum för
-        flytten. Individen kommer tas bort från din besättning och läggas till i
-        besättningen du anger.
-      </p>
-      <p>
-        Observera att du då inte längre kan ändra informationen om individen.
-        Det går inte heller att utfärda eller uppdatera digitala certifikat för
-        individen när den har flyttats.
-      </p>
-      <IndividualSellingform
-        individual={individualForSale}
-        herdOptions={genebank ? genebank.herds : []}
-        herdKey={herdKey}
-        onUpdateIndividual={handleUpdateIndividual}
-      />
-      <Button variant="contained" color="primary" onClick={sellIndividual}>
-        Sälj
-      </Button>
-    </>
+      <div className={style.textContainer}>
+        <Typography variant="body1" className={style.infoText}>
+          Ange besättningen som individen ska flyttas till, samt ett datum för
+          flytten. Individen kommer tas bort från din besättning och läggas till
+          i besättningen du anger.
+        </Typography>
+        <Typography variant="body1" className={style.infoText}>
+          Observera att du då inte längre kan ändra informationen om individen.
+          Det går inte heller att utfärda eller uppdatera digitala certifikat
+          för individen när den har flyttats.
+        </Typography>
+      </div>
+      <div className={style.formContainer}>
+        <IndividualSellingform
+          individual={individualForSale}
+          herdOptions={genebank ? genebank.herds : []}
+          onUpdateIndividual={handleUpdateIndividual}
+        />
+      </div>
+      <div>
+        <FormControl
+          required
+          error={error}
+          component="fieldset"
+          disabled={disabled}
+          className={style.checkContainer}
+        >
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={checked}
+                onChange={handleCheckbox}
+                color="primary"
+                inputProps={{ "aria-label": "primary checkbox" }}
+              />
+            }
+            label="Jag har tagit del av informationen och vill ta bort individen
+            från min besättning."
+          ></FormControlLabel>
+          <FormHelperText hidden={!error}>
+            Bekräfta att du tagit del av informationen.
+          </FormHelperText>
+        </FormControl>
+      </div>
+      <div className={style.buttonContainer}>
+        <Button variant="contained" color="primary" onClick={sellIndividual}>
+          Sälj
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/individual_sellingform.tsx
+++ b/frontend/src/individual_sellingform.tsx
@@ -8,7 +8,12 @@ import {
 import { Autocomplete } from "@material-ui/lab";
 import DateFnsUtils from "@date-io/date-fns";
 
-import { herdLabel, Individual, LimitedHerd } from "./data_context_global";
+import {
+  Genebank,
+  herdLabel,
+  Individual,
+  LimitedHerd,
+} from "./data_context_global";
 
 const useStyles = makeStyles({
   inputField: {

--- a/frontend/src/individual_sellingform.tsx
+++ b/frontend/src/individual_sellingform.tsx
@@ -29,7 +29,7 @@ export function IndividualSellingform({
 }: {
   individual: Individual;
   herdOptions: LimitedHerd[];
-  herdKey: number;
+  herdKey?: number;
   onUpdateIndividual: any;
 }) {
   const style = useStyles();
@@ -46,7 +46,6 @@ export function IndividualSellingform({
             label="Välj besättning"
             variant="outlined"
             margin="normal"
-            helperText="Lämna tom om kaninen inte har sålts"
           />
         )}
         className={style.inputField}
@@ -64,7 +63,6 @@ export function IndividualSellingform({
           label="Köpdatum"
           format="yyyy-MM-dd"
           value={individual.selling_date ?? null}
-          helperText="Lämna tom om kaninen inte har sålts"
           InputLabelProps={{
             shrink: true,
           }}

--- a/frontend/src/individual_sellingform.tsx
+++ b/frontend/src/individual_sellingform.tsx
@@ -38,7 +38,7 @@ export function IndividualSellingform({
       <Autocomplete
         key={herdKey}
         options={herdOptions}
-        value={individual.herd}
+        value={herdOptions.find((option) => option.herd == individual.herd)}
         getOptionLabel={(option: LimitedHerd) => herdLabel(option)}
         renderInput={(params) => (
           <TextField

--- a/frontend/src/individual_sellingform.tsx
+++ b/frontend/src/individual_sellingform.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
   },
 });
 
-export function IndividualSellingform({
+export function IndividualSellingForm({
   individual,
   herdOptions,
   herdKey,

--- a/frontend/src/individual_sellingform.tsx
+++ b/frontend/src/individual_sellingform.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+
+import { makeStyles, TextField } from "@material-ui/core";
+import {
+  MuiPickersUtilsProvider,
+  KeyboardDatePicker,
+} from "@material-ui/pickers";
+import { Autocomplete } from "@material-ui/lab";
+import DateFnsUtils from "@date-io/date-fns";
+
+import { herdLabel, Individual, LimitedHerd } from "./data_context_global";
+
+const useStyles = makeStyles({
+  inputField: {
+    margin: "1em 0",
+  },
+});
+
+export function IndividualSellingform({
+  individual,
+  herdOptions,
+  herdKey,
+  onUpdateIndividual,
+}: {
+  individual: Individual;
+  herdOptions: LimitedHerd[];
+  herdKey: number;
+  onUpdateIndividual: any;
+}) {
+  const style = useStyles();
+  return (
+    <>
+      <Autocomplete
+        key={herdKey}
+        options={herdOptions}
+        value={individual.herd}
+        getOptionLabel={(option: LimitedHerd) => herdLabel(option)}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label="Välj besättning"
+            variant="outlined"
+            margin="normal"
+            helperText="Lämna tom om kaninen inte har sålts"
+          />
+        )}
+        className={style.inputField}
+        onChange={(event, newValue) => {
+          newValue && onUpdateIndividual("herd", newValue.herd);
+        }}
+      />
+      <MuiPickersUtilsProvider utils={DateFnsUtils}>
+        <KeyboardDatePicker
+          autoOk
+          fullWidth={true}
+          className={style.inputField}
+          variant="inline"
+          inputVariant="outlined"
+          label="Köpdatum"
+          format="yyyy-MM-dd"
+          value={individual.selling_date ?? null}
+          helperText="Lämna tom om kaninen inte har sålts"
+          InputLabelProps={{
+            shrink: true,
+          }}
+          onChange={(event, newValue) => {
+            newValue && onUpdateIndividual("selling_date", newValue);
+          }}
+        />
+      </MuiPickersUtilsProvider>
+    </>
+  );
+}

--- a/frontend/src/individual_view.tsx
+++ b/frontend/src/individual_view.tsx
@@ -29,6 +29,7 @@ import { IndividualEdit } from "@app/individual_edit";
 import { IndividualCertificate } from "./individual_certificate";
 import { CertificateVerification } from "./certificate_verification";
 import { CertificateDownload } from "./certificate_download";
+import { IndividualSell } from "./individual_sell";
 
 const useStyles = makeStyles({
   body: {
@@ -381,6 +382,18 @@ export function IndividualView({ id }: { id: string }) {
                       }
                     })}
                 </ul>
+                {user?.canEdit(id) && (
+                  <Button
+                    className={style.editButton}
+                    variant="outlined"
+                    color="primary"
+                    onClick={() =>
+                      popup(<IndividualSell individual={individual} />)
+                    }
+                  >
+                    Sälj individ
+                  </Button>
+                )}
               </div>
               <div>
                 <h3>Föräldrar</h3>


### PR DESCRIPTION
A part of the form used for adding new animals was turned into a reusable component and now even serves for selling individuals. 
The button for selling individuals in `individual_view` should only appear if you have the permission to sell this animal (i.e. if you are an admin, the genebank manager or the owner of the individual's current herd). 
There is a bug related to this described in issue #334 . 

I tested the feature manually with an admin user and it works fine. 
When I tried with a user who only owns a certain herd, I got a 502 response back and can't find the cause of that problem. 
I'd be happy if you could give it a try as well. 