### PR TITLE
Allow generation of new(!) individual entries

### DIFF
--- a/app/tests/test_data_access.py
+++ b/app/tests/test_data_access.py
@@ -314,6 +314,22 @@ class TestDataAccess(DatabaseTest):
                 "birth_date": datetime.now() - timedelta(days=30),
                 "selling_date": datetime.now() - timedelta(days=10),
             },
+            "empty": {
+                "herd": self.herds[1].herd,
+                "origin_herd": {"herd": self.herds[0].herd},
+                "number": None,
+                "breeding": 2,
+                "birth_date": datetime.today(),
+                "selling_date": None,
+            },
+            "secondempty": {
+                "herd": self.herds[1].herd,
+                "origin_herd": {"herd": self.herds[1].herd},
+                "number": None,
+                "breeding": 2,
+                "birth_date": datetime.today(),
+                "selling_date": None,
+            },
         }
         self.assertEqual(
             da.add_individual(forms["valid"], "invalid-uuid"),
@@ -335,6 +351,15 @@ class TestDataAccess(DatabaseTest):
         ind = da.get_individual(forms["valid"]["number"], self.admin.uuid)
         self.assertIsNotNone(ind)
         self.assertEqual(ind["herd"], {"id": 1, "herd": "H1", "herd_name": "herd1"})
+
+        status = da.add_individual(forms["empty"], self.admin.uuid)
+        self.assertEqual(status, {"status": "success", "message": "Individual Created"})
+        ind = da.get_individual(forms["empty"]["number"], self.admin.uuid)
+
+        status = da.add_individual(forms["secondempty"], self.admin.uuid)
+        self.assertEqual(status, {"status": "success", "message": "Individual Created"})
+        ind = da.get_individual(forms["secondempty"]["number"], self.admin.uuid)
+        self.assertIsNotNone(ind)
 
         # Make sure you cannot add rabbits with already existing numbers
         status = da.add_individual(forms["valid"], self.admin.uuid)

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -24,6 +24,7 @@ from utils.database import HerdTracking  # isort: skip
 from utils.database import Individual  # isort: skip
 from utils.database import User  # isort: skip
 from utils.database import Weight  # isort: skip
+from utils.database import next_individual_number  # isort: skip
 
 from werkzeug.security import check_password_hash, generate_password_hash  # isort:skip
 
@@ -872,7 +873,7 @@ def add_individual(form, user_uuid):
         return {"status": "error", "message": "Forbidden"}
 
     if form.get("number", None) is None and "breeding" in form:
-        form["number"] = Breeding.next_individual_number(
+        form["number"] = next_individual_number(
             herd=form["herd"],
             birth_date=form["birth_date"],
             breeding_event=form["breeding"],

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -832,7 +832,7 @@ def form_to_individual(form, user=None):
     # Update individual fields by looping through all fields on an Individual
     # object.
     for key in vars(Individual).keys():
-        if key in form:
+        if form.get(key, None) is not None:
             if key.startswith("_"):
                 continue
             if key and key.endswith("date"):

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -429,9 +429,7 @@ def next_individual_number(herd, birth_date, breeding_event):
         if litter_size == 0:
             next_litter += 1
 
-        ind_number = (
-            f"{herd}-{str(birth_date.year)[2:4]}{next_litter}{litter_size + 1}"
-        )
+        ind_number = f"{herd}-{str(birth_date.year)[2:4]}{next_litter}{litter_size + 1}"
 
         return ind_number
 

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -402,7 +402,7 @@ class Breeding(BaseModel):
 
     def next_individual_number(herd, birth_date, breeding_event):
         """
-        Returns the next litter number for a given year and herd.
+        Returns the number for the next individual in a litter for a given year and herd.
         """
 
         try:

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -23,7 +23,6 @@ from peewee import (
     FloatField,
     ForeignKeyField,
     IntegerField,
-    JOIN,
     Model,
     OperationalError,
     PostgresqlDatabase,

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -407,7 +407,7 @@ class Breeding(BaseModel):
         """
         if isinstance(birth_date, str):
             birth_date = datetime.strptime(birth_date, "%Y-%m-%d")
-            assert(isinstance(birth_date, datetime))
+            assert isinstance(birth_date, datetime)
 
         try:
             events = (

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -413,7 +413,6 @@ def next_individual_number(herd, birth_date, breeding_event):
 
             current_herd = HerdTracking.select(
                 HerdTracking.herd.alias("herd"),
-                HerdTracking.herd_tracking_date.alias("ht_date"),
                 HerdTracking.individual.alias("i_id"),
             ).distinct()
 

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -400,6 +400,53 @@ class Breeding(BaseModel):
 
         indexes = ((("mother", "father", "birth_date"), True),)
 
+    def next_individual_number(herd, birth_date, breeding_event):
+        """
+        Returns the next litter number for a given year and herd.
+        """
+
+        try:
+            events = (
+                Breeding.select(Breeding)
+                .join(Individual, on=(Breeding.id == Individual.breeding))
+                .join(Herd, on=(Herd.id == Individual.origin_herd))
+                .where((Herd.herd == herd))
+                .order_by(Breeding.breed_date.desc())
+            ).execute()
+
+            print("Last litter number is: %s " % len(events))
+
+            for ev in events:
+                print("ev: ", ev.id, ev.breed_date)
+
+            # last_event_id = events[0]
+            # print("Last event id is: %s " % last_event_id)
+
+            next_litter = len(events)
+
+            individuals = (
+                Individual.select(Individual).where(
+                    Individual.breeding == str(breeding_event)
+                )
+            ).execute()
+
+            for ind in individuals:
+                print("ind: ", ind.id, ind.breeding.id)
+
+            litter_size = len(individuals)
+            print("Litter size is: %s " % litter_size)
+
+            ind_number = (
+                f"{herd}-{str(birth_date.year)[2:4]}{next_litter}{litter_size + 1}"
+            )
+            print("Indiv nummer : %s " % ind_number)
+
+            return ind_number
+
+        except DoesNotExist:
+            pass
+        return None
+
 
 class Individual(BaseModel):
     """

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -400,10 +400,14 @@ class Breeding(BaseModel):
 
         indexes = ((("mother", "father", "birth_date"), True),)
 
+    @staticmethod
     def next_individual_number(herd, birth_date, breeding_event):
         """
         Returns the number for the next individual in a litter for a given year and herd.
         """
+        if isinstance(birth_date, str):
+            birth_date = datetime.strptime(birth_date, "%Y-%m-%d")
+            assert(isinstance(birth_date, datetime))
 
         try:
             events = (

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -400,56 +400,41 @@ class Breeding(BaseModel):
 
         indexes = ((("mother", "father", "birth_date"), True),)
 
-    @staticmethod
-    def next_individual_number(herd, birth_date, breeding_event):
-        """
-        Returns the number for the next individual in a litter for a given year and herd.
-        """
-        if isinstance(birth_date, str):
-            birth_date = datetime.strptime(birth_date, "%Y-%m-%d")
-            assert isinstance(birth_date, datetime)
 
-        try:
-            events = (
-                Breeding.select(Breeding)
-                .join(Individual, on=(Breeding.id == Individual.breeding))
-                .join(Herd, on=(Herd.id == Individual.origin_herd))
-                .where((Herd.herd == herd))
-                .order_by(Breeding.breed_date.desc())
-            ).execute()
+def next_individual_number(herd, birth_date, breeding_event):
+    """
+    Returns the number for the next individual in a litter for a given year and herd.
+    """
+    if isinstance(birth_date, str):
+        birth_date = datetime.strptime(birth_date, "%Y-%m-%d")
+        assert isinstance(birth_date, datetime)
 
-            print("Last litter number is: %s " % len(events))
+    try:
+        events = (
+            Breeding.select(Breeding)
+            .join(Individual, on=(Breeding.id == Individual.breeding))
+            .join(Herd, on=(Herd.id == Individual.origin_herd))
+            .where((Herd.herd == herd))
+            .distinct()
+        ).execute()
 
-            for ev in events:
-                print("ev: ", ev.id, ev.breed_date)
+        next_litter = len(events)
 
-            # last_event_id = events[0]
-            # print("Last event id is: %s " % last_event_id)
-
-            next_litter = len(events)
-
-            individuals = (
-                Individual.select(Individual).where(
-                    Individual.breeding == str(breeding_event)
-                )
-            ).execute()
-
-            for ind in individuals:
-                print("ind: ", ind.id, ind.breeding.id)
-
-            litter_size = len(individuals)
-            print("Litter size is: %s " % litter_size)
-
-            ind_number = (
-                f"{herd}-{str(birth_date.year)[2:4]}{next_litter}{litter_size + 1}"
+        individuals = (
+            Individual.select(Individual).where(
+                Individual.breeding == str(breeding_event)
             )
-            print("Indiv nummer : %s " % ind_number)
+        ).execute()
 
-            return ind_number
+        litter_size = len(individuals)
 
-        except DoesNotExist:
-            pass
-        return None
+        ind_number = f"{herd}-{str(birth_date.year)[2:4]}{next_litter}{litter_size + 1}"
+
+        return ind_number
+
+    except DoesNotExist:
+        pass
+    return None
 
 
 class Individual(BaseModel):

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -214,13 +214,13 @@ export function BreedingForm({
     return true;
   };
 
-  const createEmptyIndividual = (individual: Individual): boolean => {
+  const createEmptyIndividual = (individual: Individual): any => {
     post("/api/individual", individual).then(
       (json) => {
         switch (json.status) {
           case "success": {
             userMessage("Kaninen har lagts till i din besättning.", "success");
-            return true;
+            break;
           }
           case "error": {
             switch (json.message) {
@@ -228,36 +228,35 @@ export function BreedingForm({
                 {
                   userMessage("Du är inte inloggad.", "error");
                 }
-                return false;
+                break;
               case "Individual must have a valid herd":
                 {
                   userMessage("Besättningen kunde inte hittas.", "error");
                 }
-                return false;
+                break;
               case "Forbidden": {
                 userMessage(
                   "Du saknar rättigheterna för att lägga till en kanin i besättningen.",
                   "error"
                 );
-                return false;
+                break;
               }
               default: {
                 userMessage(
                   "Något gick fel. Det här borde inte hända.",
                   "error"
                 );
-                return false;
+                break;
               }
             }
           }
         }
+        return json.status;
       },
       (error) => {
         userMessage("Något gick fel.", "error");
-        return false;
       }
     );
-    return false;
   };
 
   /**
@@ -324,7 +323,6 @@ export function BreedingForm({
         userMessage("Något gick fel", "error");
         return;
       }
-      console.log(breeding.litter_size);
 
       const originHerdNameID: HerdNameID = {
         herd: herdId,
@@ -341,17 +339,14 @@ export function BreedingForm({
         genebank: genebank?.name,
         certificate: null,
         number: null,
-        birth_date: breeding.birth_date,
+        birth_date: newBirthData.date,
         father: fatherInd,
         mother: motherInd,
-        color: null,
         color_note: null,
         death_date: null,
         death_note: null,
-        litter: breeding.id ? breeding.id : 0,
+        litter: null,
         notes: null,
-        weights: null,
-        bodyfat: null,
         herd_tracking: null,
         herd_active: true,
         active: false,
@@ -361,11 +356,12 @@ export function BreedingForm({
         claw_color: null,
         hair_notes: "",
         selling_date: null,
-        breeding: null,
+        breeding: newBirthData.id ? newBirthData.id : 0,
       };
       for (let i = 0; i < breeding.litter_size; i++) {
-        let success: boolean = createEmptyIndividual(emptyIndividual);
-        if (!success) {
+        await new Promise((r) => setTimeout(r, 2000));
+        status = createEmptyIndividual(emptyIndividual);
+        if (!status || status == "error") {
           break;
         }
       }

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -319,7 +319,7 @@ export function BreedingForm({
     if (!!newBirth) {
       userMessage("Sparat!", "success");
       handleBreedingsChanged();
-      if (!breeding.litter_size || !herdId) {
+      if (!herdId) {
         userMessage("Något gick fel", "error");
         return;
       }
@@ -346,7 +346,7 @@ export function BreedingForm({
         death_date: null,
         death_note: null,
         litter: null,
-        notes: null,
+        notes: "",
         herd_tracking: null,
         herd_active: true,
         active: false,

--- a/frontend/src/data_context_global.tsx
+++ b/frontend/src/data_context_global.tsx
@@ -45,14 +45,14 @@ export interface Individual extends LimitedIndividual {
   birth_date: string | null;
   mother: LimitedIndividual | null;
   father: LimitedIndividual | null;
-  color: string | null;
+  color?: string | null;
   color_note: string | null;
   death_date: string | null;
   death_note: string | null;
   litter: number | null;
   notes: string | null;
-  weights: Array<DateWeight> | null;
-  bodyfat: Array<DateBodyfat> | null;
+  weights?: Array<DateWeight> | null;
+  bodyfat?: Array<DateBodyfat> | null;
   herd_tracking: Array<DateValue> | null;
   herd_active: boolean;
   active: boolean;

--- a/frontend/src/data_context_global.tsx
+++ b/frontend/src/data_context_global.tsx
@@ -7,9 +7,9 @@ export interface NameID {
 }
 
 export interface HerdNameID {
-  herd_name: string;
+  herd_name?: string;
   herd: string;
-  id: number;
+  id?: number;
 }
 
 export interface DateValue {
@@ -31,16 +31,16 @@ export interface DateBodyfat {
 }
 
 export interface LimitedIndividual {
-  id: number;
-  name: string | null;
-  number: string;
+  id?: number;
+  name?: string | null;
+  number: string | null;
   sex?: string;
 }
 
 export interface Individual extends LimitedIndividual {
   herd: HerdNameID | string;
   origin_herd?: HerdNameID;
-  genebank: string;
+  genebank?: string;
   certificate: string | null;
   birth_date: string | null;
   mother: LimitedIndividual | null;


### PR DESCRIPTION
With this PR I added the backend and frontend bits needed for creating new individual identifiers that are not entered manually by an user.

-  It checks how many breeding events happened on a given year in a herd to figure out the "Kull". It assumes that this is enough information to assign the next number.
- The last number of the identifier is calculated based on the litter size of the breeding event.