### PR TITLE
Fix/basic layout

### DIFF
--- a/frontend/build.sh
+++ b/frontend/build.sh
@@ -5,6 +5,7 @@ esbuild                                          \
     --outdir=dist                                \
     --loader:.png=file                           \
     --loader:.jpg=file                           \
+    --external:/images/*                         \
     --target=es6                                 \
     --minify                                     \
     "--define:process.env.NODE_ENV='production'" \

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,8 +25,7 @@
     "jest-fetch-mock": "^3.0.3",
     "snowpack": "^2.14.0",
     "ts-jest": "^26.5.5",
-    "typescript": "^4.2.4",
-    "css-loader": "^6.2.0"
+    "typescript": "^4.2.4"
   },
   "scripts": {
     "start": "npx snowpack dev",
@@ -43,6 +42,7 @@
     "@material-ui/pickers": "^3.3.10",
     "@snowpack/plugin-react-refresh": "^2.5.0",
     "date-fns": "2.21.1",
+    "npm-font-open-sans": "^1.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",
@@ -51,6 +51,7 @@
     "react-pdf": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "styled-components": "^5.2.3",
+    "typeface-open-sans": "^1.1.13",
     "vis-data": "^7.1.2",
     "vis-network": "^9.0.4",
     "vis-util": "^5.0.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,8 @@
     "jest-fetch-mock": "^3.0.3",
     "snowpack": "^2.14.0",
     "ts-jest": "^26.5.5",
-    "typescript": "^4.2.4"
+    "typescript": "^4.2.4",
+    "css-loader": "^6.2.0"
   },
   "scripts": {
     "start": "npx snowpack dev",
@@ -42,7 +43,6 @@
     "@material-ui/pickers": "^3.3.10",
     "@snowpack/plugin-react-refresh": "^2.5.0",
     "date-fns": "2.21.1",
-    "npm-font-open-sans": "^1.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",
@@ -51,7 +51,6 @@
     "react-pdf": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "styled-components": "^5.2.3",
-    "typeface-open-sans": "^1.1.13",
     "vis-data": "^7.1.2",
     "vis-network": "^9.0.4",
     "vis-util": "^5.0.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,8 @@
     "jest-fetch-mock": "^3.0.3",
     "snowpack": "^2.14.0",
     "ts-jest": "^26.5.5",
-    "typescript": "^4.2.4"
+    "typescript": "^4.2.4",
+    "css-loader": "^6.2.0"
   },
   "scripts": {
     "start": "npx snowpack dev",

--- a/frontend/src/field_with_permission.tsx
+++ b/frontend/src/field_with_permission.tsx
@@ -4,29 +4,12 @@
  */
 import React from "react";
 import { TextField } from "@material-ui/core";
-import { makeStyles } from "@material-ui/core/styles";
 import { Autocomplete } from "@material-ui/lab";
 import {
   inputVariant,
   OptionType,
   PrivacyLevel,
 } from "@app/data_context_global";
-
-// Define styles for the form
-const useStyles = makeStyles({
-  simpleField: {
-    width: "100%",
-  },
-  permissionGroup: {
-    display: "flex",
-    flexDirection: "row",
-  },
-  permissionField: {
-    width: "200px",
-    marginTop: 0,
-    marginLeft: "5px",
-  },
-});
 
 /**
  * The FieldWithPermission function provides an input field, with the input tag
@@ -48,8 +31,6 @@ export function FieldWithPermission({
   permission: PrivacyLevel | undefined;
   setValue: Function;
 }) {
-  const classes = useStyles();
-
   const options = [
     { value: "private", label: "Endast Manager" },
     { value: "authenticated", label: "Endast Inloggade" },
@@ -58,10 +39,10 @@ export function FieldWithPermission({
 
   return (
     <>
-      <div className={classes.permissionGroup}>
+      <div className="permissionGroup">
         <TextField
           label={label}
-          className={classes.simpleField}
+          className="simpleField"
           value={value}
           variant={inputVariant}
           onChange={(e: any) => {
@@ -80,7 +61,7 @@ export function FieldWithPermission({
                 {...params}
                 label="Synlighet"
                 variant={inputVariant}
-                className={classes.permissionField}
+                className="permissionFieldExtended"
                 margin="normal"
               />
             )}

--- a/frontend/src/filter_table.tsx
+++ b/frontend/src/filter_table.tsx
@@ -470,7 +470,7 @@ export function FilterTable({
                         >
                           {column.label}
                           {orderBy === column.field ? (
-                            <span className="sortedTable">
+                            <span className="sorted">
                               {order === "desc"
                                 ? "sorted descending"
                                 : "sorted ascending"}

--- a/frontend/src/filter_table.tsx
+++ b/frontend/src/filter_table.tsx
@@ -471,7 +471,7 @@ export function FilterTable({
                         >
                           {column.label}
                           {orderBy === column.field ? (
-                            <span className="sorted">
+                            <span className="sortedTable">
                               {order === "desc"
                                 ? "sorted descending"
                                 : "sorted ascending"}

--- a/frontend/src/filter_table.tsx
+++ b/frontend/src/filter_table.tsx
@@ -36,46 +36,6 @@ import { useMessageContext } from "@app/message_context";
 import { useUserContext } from "./user_context";
 import { IndividualAdd } from "./individual_add";
 
-// Define styles
-const useStyles = makeStyles({
-  table: {
-    height: "100%",
-    padding: "5px",
-    overflowY: "scroll",
-  },
-  columnLabel: {
-    paddingRight: "30px",
-  },
-  columnSelect: {
-    zIndex: 15,
-  },
-  loading: {
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  functionLink: {
-    color: "blue",
-    textDecoration: "underline",
-    cursor: "pointer",
-  },
-  sorted: {
-    border: 0,
-    clip: "rect(0 0 0 0)",
-    height: 1,
-    margin: -1,
-    overflow: "hidden",
-    padding: 0,
-    position: "absolute",
-    top: 20,
-    width: 1,
-  },
-  search: {
-    float: "right",
-  },
-});
-
 /**
  * Column definition with sorting information. `sortBy` is used to tell the
  * sorting function which sub-field to sort by if the column value is an object,
@@ -237,7 +197,6 @@ export function FilterTable({
 }) {
   const { popup } = useMessageContext();
   const { user } = useUserContext();
-  const styles = useStyles();
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(25);
   const [order, setOrder] = React.useState("desc" as Order);
@@ -261,7 +220,7 @@ export function FilterTable({
         ),
       render: (rowData: any) => (
         <a
-          className={styles.functionLink}
+          className="functionLink"
           onClick={() =>
             popup(
               <HerdView id={rowData.herd["herd"]} />,
@@ -282,7 +241,7 @@ export function FilterTable({
       sortAs: "numbers",
       render: (rowData: any) => (
         <a
-          className={styles.functionLink}
+          className="functionLink"
           onClick={() =>
             popup(
               <IndividualView id={rowData.number} />,
@@ -317,7 +276,7 @@ export function FilterTable({
       sortAs: "numbers",
       render: (rowData: any) => (
         <a
-          className={styles.functionLink}
+          className="functionLink"
           onClick={() =>
             popup(
               <IndividualView id={rowData.mother["number"]} />,
@@ -336,7 +295,7 @@ export function FilterTable({
       sortAs: "numbers",
       render: (rowData: any) => (
         <a
-          className={styles.functionLink}
+          className="functionLink"
           onClick={() =>
             popup(
               <IndividualView id={rowData.father["number"]} />,
@@ -431,17 +390,18 @@ export function FilterTable({
     setOrderBy(property);
   };
 
-  const createSortHandler =
-    (property: keyof Individual) => (event: React.MouseEvent<unknown>) => {
-      handleRequestSort(event, property);
-    };
+  const createSortHandler = (property: keyof Individual) => (
+    event: React.MouseEvent<unknown>
+  ) => {
+    handleRequestSort(event, property);
+  };
 
   return (
     <>
       <div>
         <Autocomplete
           multiple
-          className={styles.columnLabel}
+          className="columnLabel"
           options={columns.map((v: any) => {
             return { value: v.field, label: v.label };
           })}
@@ -455,18 +415,14 @@ export function FilterTable({
             option.value == value.value
           }
           renderInput={(params) => (
-            <TextField
-              {...params}
-              variant={inputVariant}
-              margin="normal"
-            />
+            <TextField {...params} variant={inputVariant} margin="normal" />
           )}
           onChange={(event: any, newValues: OptionType[] | null) => {
             newValues && updateColumns(newValues);
           }}
         />
       </div>
-      <div className={styles.table}>
+      <div className="table">
         {individuals ? (
           <>
             {currentFilters.map((filter) => (
@@ -487,7 +443,7 @@ export function FilterTable({
             ))}
 
             <TextField
-              className={styles.search}
+              className="search"
               label="Sök"
               variant={inputVariant}
               onChange={(e) => setSearch(e.currentTarget.value)}
@@ -515,7 +471,7 @@ export function FilterTable({
                         >
                           {column.label}
                           {orderBy === column.field ? (
-                            <span className={styles.sorted}>
+                            <span className="sorted">
                               {order === "desc"
                                 ? "sorted descending"
                                 : "sorted ascending"}
@@ -534,7 +490,7 @@ export function FilterTable({
                         <TableRow key={row.number} hover tabIndex={-1}>
                           {action && (
                             <TableCell
-                              className={styles.functionLink}
+                              className="functionLink"
                               onClick={(event) => action && action(event, row)}
                             >
                               <SvgIcon component={actionIcon} />
@@ -579,7 +535,7 @@ export function FilterTable({
           </>
         ) : (
           <>
-            <div className={styles.loading}>
+            <div className="loading">
               <h2>Loading Individuals</h2>
               <CircularProgress />
             </div>

--- a/frontend/src/filter_table.tsx
+++ b/frontend/src/filter_table.tsx
@@ -9,7 +9,6 @@ import {
   Button,
   CircularProgress,
   Checkbox,
-  makeStyles,
   FormControlLabel,
   TextField,
   TableHead,

--- a/frontend/src/genebank_view.tsx
+++ b/frontend/src/genebank_view.tsx
@@ -6,36 +6,14 @@
 import React from "react";
 
 import { Genebank, Individual } from "@app/data_context_global";
-import { CircularProgress, makeStyles } from "@material-ui/core";
+import { CircularProgress, make } from "@material-ui/core";
 import { FilterTable } from "@app/filter_table";
-
-// Define styles
-const useStyles = makeStyles({
-  table: {
-    height: "100%",
-    padding: "5px",
-    overflowY: "scroll",
-  },
-  columnLabel: {
-    paddingRight: "30px",
-  },
-  columnSelect: {
-    zIndex: 15,
-  },
-  loading: {
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-});
 
 /**
  * Shows genebank information, with a list of all herds belonging to that
  * genebank.
  */
 export function GenebankView({ genebank }: { genebank: Genebank }) {
-  const styles = useStyles();
   const [individuals, setIndividuals] = React.useState(
     null as Array<Individual> | null
   );
@@ -48,7 +26,7 @@ export function GenebankView({ genebank }: { genebank: Genebank }) {
 
   return (
     <>
-      <div className={styles.table}>
+      <div className="table">
         {individuals ? (
           <FilterTable
             individuals={individuals}
@@ -61,7 +39,7 @@ export function GenebankView({ genebank }: { genebank: Genebank }) {
           />
         ) : (
           <>
-            <div className={styles.loading}>
+            <div className="loading">
               <h2>Loading Individuals</h2>
               <CircularProgress />
             </div>

--- a/frontend/src/genebanks.tsx
+++ b/frontend/src/genebanks.tsx
@@ -7,24 +7,16 @@ import React, { useState } from "react";
 import { useDataContext } from "@app/data_context";
 
 import { Genebank } from "@app/data_context_global";
-import { Button, Paper, makeStyles } from "@material-ui/core";
+import { Button, Paper } from "@material-ui/core";
 
 import { Link, useRouteMatch, useHistory } from "react-router-dom";
 import { GenebankView } from "@app/genebank_view";
-
-// Define styles
-const useStyles = makeStyles({
-  buttonBar: {
-    padding: "5px",
-  },
-});
 
 /**
  * Provides buttons to select which genebank to view, which is then done with
  * the GenebankView function.
  */
 export function Genebanks() {
-  const styles = useStyles();
   const { url } = useRouteMatch();
   const history = useHistory();
   const { genebanks } = useDataContext();
@@ -48,7 +40,7 @@ export function Genebanks() {
   return (
     <>
       <Paper>
-        <div className={styles.buttonBar}>
+        <div className="buttonBar">
           {genebanks.length > 1 &&
             genebanks.map((g: Genebank, i: number) => {
               return (

--- a/frontend/src/herdForm.tsx
+++ b/frontend/src/herdForm.tsx
@@ -34,59 +34,6 @@ import {
 import { get, updateHerd, createHerd } from "@app/communication";
 import { FieldWithPermission } from "@app/field_with_permission";
 
-// Define styles for the form
-const useStyles = makeStyles({
-  form: {
-    display: "flex",
-    flexDirection: "row",
-  },
-  simpleField: {
-    width: "100%",
-  },
-  title: {
-    fontSize: "2em",
-    borderBottom: "1px solid lightgrey",
-    margin: "5px 0 20px 0",
-  },
-  subheading: {
-    fontSize: 14,
-    borderBottom: "1px solid lightgrey",
-    margin: "20px 0 5px 0",
-  },
-  formCard: {
-    padding: "15px",
-    margin: "10px",
-    maxWidth: "450px",
-    border: "1px solid grey",
-    borderRadius: "5px",
-  },
-  editButton: {
-    float: "right",
-    margin: "20px 0 0 0",
-  },
-  editLink: {
-    color: "blue",
-    "&:hover": {
-      color: "purple",
-      cursor: "pointer",
-    },
-  },
-  spanTitle: {
-    fontWeight: "bold",
-    marginLeft: "20px",
-  },
-  contactInfo: {
-    marginBottom: "30px",
-  },
-  permissionGroup: {
-    display: "flex",
-    flexDirection: "row",
-  },
-  permissionField: {
-    width: "200px",
-  },
-});
-
 const defaultValues: Herd = {
   id: -1,
   genebank: -1,
@@ -142,7 +89,6 @@ export function HerdForm({
   const [currentView, setCurrentView] = React.useState(view);
   const [isNew, setNew] = React.useState(false);
   const history = useHistory();
-  const classes = useStyles();
 
   const contactFields: ContactField[] = [
     { field: "name", label: "Namn" },
@@ -301,10 +247,10 @@ export function HerdForm({
       {(loading && <h2>Loading...</h2>) || (
         <>
           {change && user?.canEdit(herd.herd) && (
-            <div className={classes.editButton}>
+            <div className="editButton">
               [{" "}
               <a
-                className={classes.editLink}
+                className="editLink"
                 onClick={() =>
                   setCurrentView(currentView == "form" ? "info" : "form")
                 }
@@ -314,16 +260,16 @@ export function HerdForm({
               ]
             </div>
           )}
-          <h1 className={classes.title}>
+          <h1 className="titleHerd">
             {herd ? `Besättning ${herdLabel(herd)}` : `Ny Besättning`}
           </h1>
           {(currentView == "form" && user && user.canEdit(herd.herd) && (
             <>
-              <form className={classes.form}>
+              <form className="form">
                 <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                  <div className={classes.formCard}>
+                  <div className="formCard">
                     <Typography
-                      className={classes.title}
+                      className="titleHerd"
                       color="primary"
                       gutterBottom
                     >
@@ -360,9 +306,9 @@ export function HerdForm({
                     />
                   </div>
 
-                  <div className={classes.formCard}>
+                  <div className="formCard">
                     <Typography
-                      className={classes.title}
+                      className="titleHerd"
                       color="primary"
                       gutterBottom
                     >
@@ -371,7 +317,7 @@ export function HerdForm({
 
                     <TextField
                       label="Besättningsnamn"
-                      className={classes.simpleField}
+                      className="simpleField"
                       value={herd.herd_name}
                       variant={inputVariant}
                       onChange={(e: any) => {
@@ -398,7 +344,7 @@ export function HerdForm({
                       autoOk
                       variant="inline"
                       inputVariant={inputVariant}
-                      className={classes.simpleField}
+                      className="simpleField"
                       label="Startdatum"
                       format={dateFormat}
                       value={herd.start_date ?? ""}
@@ -411,7 +357,7 @@ export function HerdForm({
                     />
                     <TextField
                       label="Besättnings-ID"
-                      className={classes.simpleField}
+                      className="simpleField"
                       disabled={!isNew}
                       value={herd.herd}
                       variant={inputVariant}
@@ -438,7 +384,7 @@ export function HerdForm({
                           {...params}
                           label="Genbank"
                           variant={inputVariant}
-                          className={classes.permissionField}
+                          className="permissionField"
                           margin="normal"
                         />
                       )}
@@ -447,10 +393,7 @@ export function HerdForm({
                       }}
                     />
 
-                    <Typography
-                      className={classes.subheading}
-                      color="textSecondary"
-                    >
+                    <Typography className="subheading" color="textSecondary">
                       Besättningen har{" "}
                       {herd?.individuals ? herd.individuals.length : 0}{" "}
                       individer
@@ -467,10 +410,10 @@ export function HerdForm({
               </Button>
             </>
           )) || (
-            <div className={classes.contactInfo}>
+            <div className="contactInfo">
               {herd.name && (
                 <>
-                  <span className={classes.spanTitle}>Kontaktperson: </span>
+                  <span className="spanTitle">Kontaktperson: </span>
                   {herd.name}
                   {herd.email && (
                     <>

--- a/frontend/src/herdForm.tsx
+++ b/frontend/src/herdForm.tsx
@@ -18,7 +18,6 @@ import {
   KeyboardDatePicker,
 } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
-import { makeStyles } from "@material-ui/core/styles";
 import { useDataContext } from "@app/data_context";
 import { useUserContext } from "@app/user_context";
 import { useMessageContext } from "@app/message_context";

--- a/frontend/src/herd_view.tsx
+++ b/frontend/src/herd_view.tsx
@@ -26,28 +26,6 @@ import { IndividualEdit } from "@app/individual_edit";
 import { useUserContext } from "@app/user_context";
 import { BreedingList } from "./breeding_list";
 
-const useStyles = makeStyles({
-  container: {
-    padding: "20px",
-  },
-  title: {
-    fontSize: "1.33em",
-    fontWeight: "bold",
-  },
-  animalList: {
-    cursor: "pointer",
-    "&:hover": {
-      color: "blue",
-    },
-  },
-  loading: {
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-});
-
 interface TabPanelProps
   extends React.DetailedHTMLProps<
     React.HTMLAttributes<HTMLDivElement>,
@@ -90,11 +68,11 @@ export function HerdView({ id }: { id: string | undefined }) {
   const { user } = useUserContext();
   const { genebanks } = useDataContext();
   const [algo, set_algo] = React.useState("Martin" as "Martin" | "Dan");
-  const pedigree = React.useMemo(
-    () => herdPedigree(genebanks, id, 5, algo),
-    [genebanks, id, algo]
-  );
-  const style = useStyles();
+  const pedigree = React.useMemo(() => herdPedigree(genebanks, id, 5, algo), [
+    genebanks,
+    id,
+    algo,
+  ]);
 
   React.useEffect(() => {
     if (id) {
@@ -125,7 +103,7 @@ export function HerdView({ id }: { id: string | undefined }) {
 
   return (
     <>
-      <Paper className={style.container}>
+      <Paper className="container">
         {React.useMemo(
           () => (
             <HerdForm id={id} view="info" />
@@ -168,7 +146,7 @@ export function HerdView({ id }: { id: string | undefined }) {
               }
             />
           ) : (
-            <div className={style.loading}>
+            <div className="loading">
               <h2>Loading Individuals</h2>
               <CircularProgress />
             </div>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,27 +11,6 @@ import { WithMessageContext } from "@app/message_context";
 import { WithBreedingContext } from "@app/breeding_context";
 import { Navigation } from "@app/navigation";
 
-const CSS = sc.createGlobalStyle`
-  html {
-    margin: 0;
-    padding: 0;
-    height: 100%;
-    width: 100%;
-  }
-  body {
-    font-family: 'Roboto';
-    background: #ddd left / cover no-repeat url('/images/background.jpg') fixed;
-    margin: 0;
-    padding: 0 5px;
-    min-height: calc(100vh - 56px);
-    width: 100%;
-    @media (min-width:660px): {
-      background: #ddd center / cover no-repeat url('/images/background.jpg') fixed;
-      padding: 0 20px;
-    },
-  }
-`;
-
 const Main = (
   <>
     <CssBaseline />
@@ -46,7 +25,6 @@ const Main = (
         </WithUserContext>
       </WithDataContext>
     </BrowserRouter>
-    <CSS />
   </>
 );
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import styled, * as sc from "styled-components";
 import CssBaseline from "@material-ui/core/CssBaseline";
-import { makeStyles } from "@material-ui/core/styles";
 import { BrowserRouter } from "react-router-dom";
 
 import { WithUserContext } from "@app/user_context";

--- a/frontend/src/navigation.tsx
+++ b/frontend/src/navigation.tsx
@@ -1,10 +1,7 @@
 import * as React from "react";
 import { Switch, Route, useLocation, Redirect, Link } from "react-router-dom";
 
-import {
-  createMuiTheme,
-  ThemeProvider,
-} from "@material-ui/core/styles";
+import { createMuiTheme, ThemeProvider } from "@material-ui/core/styles";
 import { svSE } from "@material-ui/core/locale";
 import Paper from "@material-ui/core/Paper";
 import HomeIcon from "@material-ui/icons/Home";
@@ -53,7 +50,7 @@ import {
 } from "@material-ui/core";
 import { MenuProps } from "@material-ui/core/Menu";
 
-import './style.css';
+import "./style.css";
 
 const StyledMenu = withStyles({
   paper: {
@@ -254,77 +251,91 @@ export function Navigation() {
 
   const { Tabs, TabbedRoutes } = ui.useRoutedTabs(tabs);
 
+  return (
+    <>
+      <ThemeProvider theme={theme}>
+        {/* Insert the tab menu */}
+        <div className="menu">
+          <Button
+            aria-controls="customized-menu"
+            aria-haspopup="true"
+            className="menuButton"
+            onClick={handleClick}
+          >
+            <span className="trigram">☰</span>
+            <Typography variant="subtitle1">Menu</Typography>
+          </Button>
 
-  return <>
-    {/* Insert the tab menu */}
-    <div className="menu">
-
-      <Button
-          aria-controls="customized-menu"
-          aria-haspopup="true"
-          className="menuButton"
-          onClick={handleClick}
-        >
-        <span className="trigram">☰</span>
-        <Typography variant='subtitle1'>Menu</Typography>
-      </Button>
-
-      <StyledMenu
-        id="customized-menu"
-        anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
-        onClose={handleClose}
-      >
-        {tabs.map(tab =>
-          <Link to={tab.path ?? '/'}
+          <StyledMenu
+            id="customized-menu"
+            anchorEl={anchorEl}
+            keepMounted
+            open={Boolean(anchorEl)}
+            onClose={handleClose}
+          >
+            {tabs.map((tab) => (
+              <Link
+                to={tab.path ?? "/"}
                 className="link"
-                style={{display: tab.visible === false ? 'none' : undefined}}
-                onClick={() => {tab.on_click && tab.on_click(); handleClose();}}>
-            <StyledMenuItem>
-              <ListItemIcon>
-                {tab.icon}
-              </ListItemIcon>
-              <ListItemText primary={tab.label} />
-            </StyledMenuItem>
-          </Link>
-        )}
-      </StyledMenu>
-
-      {/* <Tabs centered/> */}
-    </div>
-    
-    
+                style={{ display: tab.visible === false ? "none" : undefined }}
+                onClick={() => {
+                  tab.on_click && tab.on_click();
+                  handleClose();
+                }}
+              >
+                <StyledMenuItem>
+                  <ListItemIcon>{tab.icon}</ListItemIcon>
+                  <ListItemText primary={tab.label} />
+                </StyledMenuItem>
+              </Link>
+            ))}
+          </StyledMenu>
+          {/* <Tabs centered/> */}
+        </div>
 
         {/* Declare routes, and what component should be rendered for each
          * route.
          */}
 
-    <div className="wrapper">
-      <Paper className="main">
-        <Switch>
-          {TabbedRoutes}
-          <ui.Routed path="/herd/:id">
-            {params => <Restricted><HerdView id={params.id}/></Restricted>}
-          </ui.Routed>
-          <ui.Routed path="/individual/:id">
-            {params => <Restricted><IndividualView id={params.id} /></Restricted>}
-          </ui.Routed>
-          <ui.Routed path="/individual-pedigree/:id/:generations?">
-            {params =>
-              <Restricted>
-                <IndividualPedigree id={params.id} generations={params.generations ? +params.generations : 5}/>
-              </Restricted>}
-          </ui.Routed>
-          <ui.Routed path="/herd-pedigree/:id">
-            {params => <Restricted><HerdPedigree id={params.id}/></Restricted>}
-          </ui.Routed>
-          <Route path="/">
-            Welcome!
-          </Route>
-        </Switch>
-      </Paper>
-    </div>
+        <div className="wrapper">
+          <Paper className="main">
+            <Switch>
+              {TabbedRoutes}
+              <ui.Routed path="/herd/:id">
+                {(params) => (
+                  <Restricted>
+                    <HerdView id={params.id} />
+                  </Restricted>
+                )}
+              </ui.Routed>
+              <ui.Routed path="/individual/:id">
+                {(params) => (
+                  <Restricted>
+                    <IndividualView id={params.id} />
+                  </Restricted>
+                )}
+              </ui.Routed>
+              <ui.Routed path="/individual-pedigree/:id/:generations?">
+                {(params) => (
+                  <Restricted>
+                    <IndividualPedigree
+                      id={params.id}
+                      generations={params.generations ? +params.generations : 5}
+                    />
+                  </Restricted>
+                )}
+              </ui.Routed>
+              <ui.Routed path="/herd-pedigree/:id">
+                {(params) => (
+                  <Restricted>
+                    <HerdPedigree id={params.id} />
+                  </Restricted>
+                )}
+              </ui.Routed>
+              <Route path="/">Welcome!</Route>
+            </Switch>
+          </Paper>
+        </div>
 
         <Footer />
       </ThemeProvider>

--- a/frontend/src/navigation.tsx
+++ b/frontend/src/navigation.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { Switch, Route, useLocation, Redirect, Link } from "react-router-dom";
 
 import {
-  makeStyles,
   createMuiTheme,
   ThemeProvider,
 } from "@material-ui/core/styles";
@@ -33,16 +32,28 @@ import { HerdPedigree } from "@app/herd_pedigree";
 import { useUserContext } from "@app/user_context";
 import { InbreedingForm } from "@app/testbreed_form";
 import { Register } from "@app/register";
-import { About, Gotlandskaninen, Mellerudskaninen, Medlem, Kontakt, Footer
-        } from '@app/static_pages'
-import { Forum } from '@app/forum'
-import * as ui from '@app/ui_utils'
-import { Button, ListItemIcon, ListItemText, Menu, MenuItem, Typography,
-        withStyles } from '@material-ui/core';
-import { MenuProps } from '@material-ui/core/Menu';
-import './style.css';
-// Define styles for tab menu
+import {
+  About,
+  Gotlandskaninen,
+  Mellerudskaninen,
+  Medlem,
+  Kontakt,
+  Footer,
+} from "@app/static_pages";
+import { Forum } from "@app/forum";
+import * as ui from "@app/ui_utils";
+import {
+  Button,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Typography,
+  withStyles,
+} from "@material-ui/core";
+import { MenuProps } from "@material-ui/core/Menu";
 
+import './style.css';
 
 const StyledMenu = withStyles({
   paper: {
@@ -86,13 +97,14 @@ function Restricted(props: { children: React.ReactElement }) {
 }
 
 export function Navigation() {
-  const {logout} = useUserContext();
-  const {user} = useUserContext();
-  const [showLogo, setShowLogo] = React.useState(true)
-  const [showLogoText, setShowLogoText] = React.useState(false)
-  const is_admin = !!(user?.is_manager || user?.is_admin)
-  const is_owner = !!(user?.is_owner && user.is_owner.length > 0)
-  const is_logged_in = !!user
+  const { logout } = useUserContext();
+  const { user } = useUserContext();
+  const [showLogo, setShowLogo] = React.useState(true);
+  const [showLogoText, setShowLogoText] = React.useState(false);
+  const is_admin = !!(user?.is_manager || user?.is_admin);
+  const is_owner = !!(user?.is_owner && user.is_owner.length > 0);
+  const is_logged_in = !!user;
+  const theme = createMuiTheme({}, svSE);
 
   const tabs: ui.RoutedTab[] = [
     {
@@ -242,6 +254,7 @@ export function Navigation() {
 
   const { Tabs, TabbedRoutes } = ui.useRoutedTabs(tabs);
 
+
   return <>
     {/* Insert the tab menu */}
     <div className="menu">
@@ -280,6 +293,8 @@ export function Navigation() {
 
       {/* <Tabs centered/> */}
     </div>
+    
+    
 
         {/* Declare routes, and what component should be rendered for each
          * route.

--- a/frontend/src/navigation.tsx
+++ b/frontend/src/navigation.tsx
@@ -33,102 +33,16 @@ import { HerdPedigree } from "@app/herd_pedigree";
 import { useUserContext } from "@app/user_context";
 import { InbreedingForm } from "@app/testbreed_form";
 import { Register } from "@app/register";
-import {
-  About,
-  Gotlandskaninen,
-  Mellerudskaninen,
-  Medlem,
-  Kontakt,
-  Footer,
-} from "@app/static_pages";
-import { Forum } from "@app/forum";
-import * as ui from "@app/ui_utils";
-import {
-  Button,
-  ListItemIcon,
-  ListItemText,
-  Menu,
-  MenuItem,
-  Typography,
-  withStyles,
-} from "@material-ui/core";
-import { MenuProps } from "@material-ui/core/Menu";
-
+import { About, Gotlandskaninen, Mellerudskaninen, Medlem, Kontakt, Footer
+        } from '@app/static_pages'
+import { Forum } from '@app/forum'
+import * as ui from '@app/ui_utils'
+import { Button, ListItemIcon, ListItemText, Menu, MenuItem, Typography,
+        withStyles } from '@material-ui/core';
+import { MenuProps } from '@material-ui/core/Menu';
+import './style.css';
 // Define styles for tab menu
-const useStyles = makeStyles({
-  menu: {
-    position: "fixed",
-    zIndex: 100,
-    left: 0,
-    top: 0,
-    width: "100%",
-    height: "51px",
-    background: "rgba(255,255,255,0.95)",
-    borderBottom: "1px solid #aaa",
-  },
-  wrapper: {
-    position: "relative",
-    borderTop: "1px solid white",
-    borderBottom: "1px solid white",
-  },
-  main: {
-    opacity: 0.9,
-    position: "relative",
-    marginTop: "calc(10vh)",
-    marginBottom: "210px",
-    marginLeft: 0,
-    marginRight: 0,
-    padding: "10px",
-    minHeight: "calc(45vh)",
-    ["@media (min-width:660px)"]: {
-      marginLeft: "20px",
-      marginRight: "20px",
-    },
-  },
-  link: {
-    textDecoration: "none",
-    fontFamily: "Open Sans",
-    color: "#222",
-  },
-  logo: {
-    position: "fixed",
-    zIndex: -3,
-    width: "100%",
-    textAlign: "center",
-    top: "10vh",
-    justifyContent: "center",
-    fontVariant: "small-caps",
-    fontSize: "2.5em",
-    color: "#eee",
-    ["@media (min-width:660px)"]: {
-      fontSize: "4em",
-      color: "#222",
-    },
-  },
-  hidden: {
-    visibility: "hidden",
-  },
 
-  menuButton: {
-    height: "52px",
-    fontSize: "1.0em",
-    ["@media (min-width:660px)"]: {
-      fontSize: "1.2em",
-    },
-  },
-  trigram: {
-    fontSize: "1.8em",
-    paddingRight: "7px",
-    marginTop: "-5px",
-    ["@media (min-width:660px)"]: {
-      fontSize: "2.0em",
-      marginTop: "-7px",
-    },
-  },
-  listItem: {
-    display: "block",
-  },
-});
 
 const StyledMenu = withStyles({
   paper: {
@@ -172,15 +86,13 @@ function Restricted(props: { children: React.ReactElement }) {
 }
 
 export function Navigation() {
-  const classes = useStyles();
-  const { logout } = useUserContext();
-  const { user } = useUserContext();
-  const [showLogo, setShowLogo] = React.useState(true);
-  const [showLogoText, setShowLogoText] = React.useState(false);
-  const is_admin = !!(user?.is_manager || user?.is_admin);
-  const is_owner = !!(user?.is_owner && user.is_owner.length > 0);
-  const is_logged_in = !!user;
-  const theme = createMuiTheme({}, svSE);
+  const {logout} = useUserContext();
+  const {user} = useUserContext();
+  const [showLogo, setShowLogo] = React.useState(true)
+  const [showLogoText, setShowLogoText] = React.useState(false)
+  const is_admin = !!(user?.is_manager || user?.is_admin)
+  const is_owner = !!(user?.is_owner && user.is_owner.length > 0)
+  const is_logged_in = !!user
 
   const tabs: ui.RoutedTab[] = [
     {
@@ -330,96 +242,74 @@ export function Navigation() {
 
   const { Tabs, TabbedRoutes } = ui.useRoutedTabs(tabs);
 
-  return (
-    <>
-      <ThemeProvider theme={theme}>
-        {/* Insert the tab menu */}
-        <div className={classes.menu}>
-          <Button
-            aria-controls="customized-menu"
-            aria-haspopup="true"
-            className={classes.menuButton}
-            onClick={handleClick}
-          >
-            <span className={classes.trigram}>☰</span>
-            <Typography variant="subtitle1">Menu</Typography>
-          </Button>
+  return <>
+    {/* Insert the tab menu */}
+    <div className="menu">
 
-          <StyledMenu
-            id="customized-menu"
-            anchorEl={anchorEl}
-            keepMounted
-            open={Boolean(anchorEl)}
-            onClose={handleClose}
-          >
-            {tabs.map((tab) => (
-              <Link
-                to={tab.path ?? "/"}
-                className={classes.link}
-                style={{ display: tab.visible === false ? "none" : undefined }}
-                onClick={() => {
-                  tab.on_click && tab.on_click();
-                  handleClose();
-                }}
-              >
-                <StyledMenuItem>
-                  <ListItemIcon>{tab.icon}</ListItemIcon>
-                  <ListItemText primary={tab.label} />
-                </StyledMenuItem>
-              </Link>
-            ))}
-          </StyledMenu>
+      <Button
+          aria-controls="customized-menu"
+          aria-haspopup="true"
+          className="menuButton"
+          onClick={handleClick}
+        >
+        <span className="trigram">☰</span>
+        <Typography variant='subtitle1'>Menu</Typography>
+      </Button>
 
-          {/* <Tabs centered/> */}
-        </div>
-        <h1 className={`${classes.logo} ${!showLogoText && classes.hidden}`}>
-          Föreningen <br />
-          Gotlandskaninen
-        </h1>
+      <StyledMenu
+        id="customized-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        {tabs.map(tab =>
+          <Link to={tab.path ?? '/'}
+                className="link"
+                style={{display: tab.visible === false ? 'none' : undefined}}
+                onClick={() => {tab.on_click && tab.on_click(); handleClose();}}>
+            <StyledMenuItem>
+              <ListItemIcon>
+                {tab.icon}
+              </ListItemIcon>
+              <ListItemText primary={tab.label} />
+            </StyledMenuItem>
+          </Link>
+        )}
+      </StyledMenu>
+
+      {/* <Tabs centered/> */}
+    </div>
 
         {/* Declare routes, and what component should be rendered for each
          * route.
          */}
 
-        <div className={classes.wrapper}>
-          <Paper className={classes.main}>
-            <Switch>
-              {TabbedRoutes}
-              <ui.Routed path="/herd/:id">
-                {(params) => (
-                  <Restricted>
-                    <HerdView id={params.id} />
-                  </Restricted>
-                )}
-              </ui.Routed>
-              <ui.Routed path="/individual/:id">
-                {(params) => (
-                  <Restricted>
-                    <IndividualView id={params.id} />
-                  </Restricted>
-                )}
-              </ui.Routed>
-              <ui.Routed path="/individual-pedigree/:id/:generations?">
-                {(params) => (
-                  <Restricted>
-                    <IndividualPedigree
-                      id={params.id}
-                      generations={params.generations ? +params.generations : 5}
-                    />
-                  </Restricted>
-                )}
-              </ui.Routed>
-              <ui.Routed path="/herd-pedigree/:id">
-                {(params) => (
-                  <Restricted>
-                    <HerdPedigree id={params.id} />
-                  </Restricted>
-                )}
-              </ui.Routed>
-              <Route path="/">Welcome!</Route>
-            </Switch>
-          </Paper>
-        </div>
+    <div className="wrapper">
+      <Paper className="main">
+        <Switch>
+          {TabbedRoutes}
+          <ui.Routed path="/herd/:id">
+            {params => <Restricted><HerdView id={params.id}/></Restricted>}
+          </ui.Routed>
+          <ui.Routed path="/individual/:id">
+            {params => <Restricted><IndividualView id={params.id} /></Restricted>}
+          </ui.Routed>
+          <ui.Routed path="/individual-pedigree/:id/:generations?">
+            {params =>
+              <Restricted>
+                <IndividualPedigree id={params.id} generations={params.generations ? +params.generations : 5}/>
+              </Restricted>}
+          </ui.Routed>
+          <ui.Routed path="/herd-pedigree/:id">
+            {params => <Restricted><HerdPedigree id={params.id}/></Restricted>}
+          </ui.Routed>
+          <Route path="/">
+            Welcome!
+          </Route>
+        </Switch>
+      </Paper>
+    </div>
 
         <Footer />
       </ThemeProvider>

--- a/frontend/src/navigation.tsx
+++ b/frontend/src/navigation.tsx
@@ -74,12 +74,12 @@ const useStyles = makeStyles({
   main: {
     opacity: 0.9,
     position: "relative",
-    marginTop: "calc(8vh)",
+    marginTop: "calc(10vh)",
     marginBottom: "210px",
     marginLeft: 0,
     marginRight: 0,
     padding: "10px",
-    minHeight: "calc(100vh - 271px)",
+    minHeight: "calc(45vh)",
     ["@media (min-width:660px)"]: {
       marginLeft: "20px",
       marginRight: "20px",
@@ -108,18 +108,7 @@ const useStyles = makeStyles({
   hidden: {
     visibility: "hidden",
   },
-  logoImageWrapper: {
-    position: "fixed",
-    zIndex: -4,
-    width: "95%",
-    textAlign: "center",
-    top: "80vh",
-  },
-  logoImage: {
-    width: "15vh",
-    maxWidth: "90vw",
-    float: "right",
-  },
+
   menuButton: {
     height: "52px",
     fontSize: "1.0em",
@@ -387,17 +376,6 @@ export function Navigation() {
           Föreningen <br />
           Gotlandskaninen
         </h1>
-        <div
-          className={`${classes.logoImageWrapper} ${
-            !showLogo && classes.hidden
-          }`}
-        >
-          <img
-            src="/images/logo.png"
-            alt="logo"
-            className={classes.logoImage}
-          />
-        </div>
 
         {/* Declare routes, and what component should be rendered for each
          * route.

--- a/frontend/src/sorted_table.tsx
+++ b/frontend/src/sorted_table.tsx
@@ -221,7 +221,7 @@ export function SortedTable({
                         >
                           {column.label}
                           {orderBy === column.field ? (
-                            <span className="sortedTable">
+                            <span className="sorted">
                               {order === "desc"
                                 ? "sorted descending"
                                 : "sorted ascending"}

--- a/frontend/src/sorted_table.tsx
+++ b/frontend/src/sorted_table.tsx
@@ -195,7 +195,7 @@ export function SortedTable({
   return (
     <>
       <div
-        className={props.className ?? table}
+        className={props.className ?? "table"}
         style={props.style ?? props.style}
       >
         {data ? (

--- a/frontend/src/sorted_table.tsx
+++ b/frontend/src/sorted_table.tsx
@@ -222,7 +222,7 @@ export function SortedTable({
                         >
                           {column.label}
                           {orderBy === column.field ? (
-                            <span className="sorted">
+                            <span className="sortedTable">
                               {order === "desc"
                                 ? "sorted descending"
                                 : "sorted ascending"}

--- a/frontend/src/sorted_table.tsx
+++ b/frontend/src/sorted_table.tsx
@@ -19,44 +19,6 @@ import {
   Button,
 } from "@material-ui/core";
 
-const useStyles = makeStyles({
-  table: {
-    padding: "5px",
-    overflowY: "scroll",
-  },
-  columnLabel: {
-    paddingRight: "30px",
-  },
-  columnSelect: {
-    zIndex: 15,
-  },
-  loading: {
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  functionLink: {
-    color: "blue",
-    textDecoration: "underline",
-    cursor: "pointer",
-  },
-  sorted: {
-    border: 0,
-    clip: "rect(0 0 0 0)",
-    height: 1,
-    margin: -1,
-    overflow: "hidden",
-    padding: 0,
-    position: "absolute",
-    top: 20,
-    width: 1,
-  },
-  bottomButton: {
-    float: "left",
-  },
-});
-
 /**
  * Column definition with sorting information. `sortBy` is used to tell the
  * sorting function which sub-field to sort by if the column value is an object,
@@ -176,7 +138,6 @@ export function SortedTable({
   data,
   ...props
 }: { columns: Column[]; data: any[] } & Record<string, any>) {
-  const styles = useStyles();
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(props.rowsPerPage ?? 25);
   const [selected, setSelected] = React.useState(null as number | null);
@@ -234,7 +195,7 @@ export function SortedTable({
   return (
     <>
       <div
-        className={props.className ?? styles.table}
+        className={props.className ?? table}
         style={props.style ?? props.style}
       >
         {data ? (
@@ -261,7 +222,7 @@ export function SortedTable({
                         >
                           {column.label}
                           {orderBy === column.field ? (
-                            <span className={styles.sorted}>
+                            <span className="sorted">
                               {order === "desc"
                                 ? "sorted descending"
                                 : "sorted ascending"}
@@ -316,7 +277,7 @@ export function SortedTable({
             </TableContainer>
             {props.addButton && (
               <Button
-                className={styles.bottomButton}
+                className="bottomButton"
                 variant="contained"
                 color="primary"
                 onClick={props.addButton}
@@ -336,7 +297,7 @@ export function SortedTable({
           </>
         ) : (
           <>
-            <div className={styles.loading}>
+            <div className="loading">
               <h2>Laddar</h2>
               <CircularProgress />
             </div>

--- a/frontend/src/sorted_table.tsx
+++ b/frontend/src/sorted_table.tsx
@@ -7,7 +7,6 @@
 import React from "react";
 import {
   CircularProgress,
-  makeStyles,
   TableHead,
   TableRow,
   TableCell,

--- a/frontend/src/static_pages.tsx
+++ b/frontend/src/static_pages.tsx
@@ -2,209 +2,222 @@
  * @file This file contains the static pages of the site.
  */
 
-import * as React from 'react'
-import { makeStyles } from '@material-ui/core/styles';
-import { Typography } from '@material-ui/core';
-import './style.css';
-
+import * as React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import { Typography } from "@material-ui/core";
+import "./style.css";
 
 // jscpd:ignore-start
 
 export function About() {
-
-  return <div className="staticMain">
-    <Typography variant='h3' className="heading">Föreningen</Typography>
-    <Typography variant='body1' className="pSpace">
-      <p>
-        Gotlandskaninen är en rest av den gamla svenska lantraskaninen.
-        På 1970-talet uppmärksammades att det fanns några gårdar på
-        Gotland som hade kvar kaniner av den gamla stammen. De gavs då
-        namnet Gotlandskanin. Efter en inventering 1993 slöts
-        rasregistret och dagens Gotlandskaniner är ättlingar till
-        inventeringsdjuren.
-      </p>
-      <p>
-        En annan rest av den gamla lantraskaninen är den så kallade
-        Mellerudskaninen. Den fanns i en besättning hos Edith Johansson, som bodde
-        nära Mellerud i Dalsland. Kaninerna liknar mycket Gotlandskaninen i
-        kroppsbyggnaden, men finns bara som brokigt svartvita (holländarteckning)
-        eller som helvita (albino).
-      </p>
-      <p>
-        Föreningen Gotlandskaninens syfte är att bevara den svenska
-        lantraskaninen för framtiden samt att sprida kunskap om rasen
-        och dess roll i självhushållet. Bevarandearbetet organiseras
-        i form av genbanksbesättningar, där avel på Gotlands- respektive
-        Mellerudskanin bedrivs.
-      </p>
-    </Typography>
-  </div>
+  return (
+    <div className="staticMain">
+      <Typography variant="h3" className="heading">
+        Föreningen
+      </Typography>
+      <Typography variant="body1" className="pSpace">
+        <p>
+          Gotlandskaninen är en rest av den gamla svenska lantraskaninen. På
+          1970-talet uppmärksammades att det fanns några gårdar på Gotland som
+          hade kvar kaniner av den gamla stammen. De gavs då namnet
+          Gotlandskanin. Efter en inventering 1993 slöts rasregistret och dagens
+          Gotlandskaniner är ättlingar till inventeringsdjuren.
+        </p>
+        <p>
+          En annan rest av den gamla lantraskaninen är den så kallade
+          Mellerudskaninen. Den fanns i en besättning hos Edith Johansson, som
+          bodde nära Mellerud i Dalsland. Kaninerna liknar mycket
+          Gotlandskaninen i kroppsbyggnaden, men finns bara som brokigt
+          svartvita (holländarteckning) eller som helvita (albino).
+        </p>
+        <p>
+          Föreningen Gotlandskaninens syfte är att bevara den svenska
+          lantraskaninen för framtiden samt att sprida kunskap om rasen och dess
+          roll i självhushållet. Bevarandearbetet organiseras i form av
+          genbanksbesättningar, där avel på Gotlands- respektive Mellerudskanin
+          bedrivs.
+        </p>
+      </Typography>
+    </div>
+  );
 }
 
 export function Gotlandskaninen() {
-
-  return <div className="staticMain">
-    <Typography variant='h3' className="heading">Gotlandskaninen</Typography>
-    <Typography variant='body1' className="pSpace">
-      <p>
-        Gotlandskaninen är en rest av den gamla svenska lantraskaninen. På
-        1970-talet uppmärksammades att det fanns några gårdar på Gotland som hade
-        kvar kaniner av den gamla stammen. De gavs då namnet Gotlandskanin. Efter
-        en inventering 1993 slöts rasregistret och dagens Gotlandskaniner är
-        ättlingar till inventeringsdjuren.
-      </p>
-      <p>
-        En fullvuxen Gotlandskanin väger 3-4 kg. Öronen är upprättstående och
-        pälsen kort. Färg och teckning varierar mycket, och de flesta typer som
-        förekommer bland raskaniner återfinns hos gotlänningen, men oftast i
-        mindre utpräglad form.
-      </p>
-      <p>
-        Till temperamentet är Gotlandskaninen livlig och nyfiken och visar ofta
-        stort intresse för sin omgivning. Normalt får Gotlandskaninen 6-8 ungar
-        per kull. Ungarna tillväxer relativt långsamt i jämförelse med utpräglade
-        produktionsraser. Men å andra sidan är man normalt återhållsam med
-        kraftfoder till Gotlandskaniner. Basfödan är hö, eller på sommarhalvåret,
-        gräs och örter.
-      </p>
-      <p>
-        Bevarandearbetet organiseras av Föreningen Gotlandskaninen i ett
-        genbankssystem. Aveln sker i speciella besättningar som föreningen
-        godkänt. Det finns ungefär 150 sådana besättningar spridda över hela
-        Sverige för Gotlandskanin. De rapporterar till föreningen vad som sker i
-        besättningen och utfärdar stamtavlor (genbanksintyg) för de djur som går
-        vidare i avelsarbetet i gamla eller nya besättningar.
-      </p>
-      <p>
-        Om du är intresserad av att veta mer, eller vill starta en
-        genbanksbesättning för Gotlandskanin, kontakta genbanksansvarig,
-        <a href="mailto:gotlandskanin@gotlandskaninen.se">
-          gotlandskanin@gotlandskaninen.se
-        </a>.
-      </p>
-    </Typography>
-  </div>
+  return (
+    <div className="staticMain">
+      <Typography variant="h3" className="heading">
+        Gotlandskaninen
+      </Typography>
+      <Typography variant="body1" className="pSpace">
+        <p>
+          Gotlandskaninen är en rest av den gamla svenska lantraskaninen. På
+          1970-talet uppmärksammades att det fanns några gårdar på Gotland som
+          hade kvar kaniner av den gamla stammen. De gavs då namnet
+          Gotlandskanin. Efter en inventering 1993 slöts rasregistret och dagens
+          Gotlandskaniner är ättlingar till inventeringsdjuren.
+        </p>
+        <p>
+          En fullvuxen Gotlandskanin väger 3-4 kg. Öronen är upprättstående och
+          pälsen kort. Färg och teckning varierar mycket, och de flesta typer
+          som förekommer bland raskaniner återfinns hos gotlänningen, men oftast
+          i mindre utpräglad form.
+        </p>
+        <p>
+          Till temperamentet är Gotlandskaninen livlig och nyfiken och visar
+          ofta stort intresse för sin omgivning. Normalt får Gotlandskaninen 6-8
+          ungar per kull. Ungarna tillväxer relativt långsamt i jämförelse med
+          utpräglade produktionsraser. Men å andra sidan är man normalt
+          återhållsam med kraftfoder till Gotlandskaniner. Basfödan är hö, eller
+          på sommarhalvåret, gräs och örter.
+        </p>
+        <p>
+          Bevarandearbetet organiseras av Föreningen Gotlandskaninen i ett
+          genbankssystem. Aveln sker i speciella besättningar som föreningen
+          godkänt. Det finns ungefär 150 sådana besättningar spridda över hela
+          Sverige för Gotlandskanin. De rapporterar till föreningen vad som sker
+          i besättningen och utfärdar stamtavlor (genbanksintyg) för de djur som
+          går vidare i avelsarbetet i gamla eller nya besättningar.
+        </p>
+        <p>
+          Om du är intresserad av att veta mer, eller vill starta en
+          genbanksbesättning för Gotlandskanin, kontakta genbanksansvarig,
+          <a href="mailto:gotlandskanin@gotlandskaninen.se">
+            gotlandskanin@gotlandskaninen.se
+          </a>
+          .
+        </p>
+      </Typography>
+    </div>
+  );
 }
 
 export function Mellerudskaninen() {
-
-  return <div className="staticMain">
-    <Typography variant='h3' className="heading">Mellerudskaninen</Typography>
-    <Typography variant='body1' className="pSpace">
-      <p>
-        Mellerudskaninen är en rest av den gamla svenska lantraskaninen. Den
-        fanns i en besättning hos Edith Johansson, som bodde nära Mellerud i
-        Dalsland. Kaninerna gavs därför namnet Mellerudskanin.
-      </p>
-      <p>
-        Kaninerna liknar mycket Gotlandskaninen i kroppsbyggnaden, men finns
-        bara som brokigt svartvita (holländarteckning) eller som helvita
-        (albino). Vuxna djur väger runt 3 kg, har kort päls och upprättstående
-        öron. Normalt får Mellerudskaninerna 4-6 ungar. Mellerudskaninen
-        uppfattas ofta som något lugnare än Gotlandskaninen.
-      </p>
-      <p>
-        I oktober 2001 gjordes ett första besök hos ”Edith i Sjöskogen” sedan
-        Föreningen Gotlandskaninen blivit uppmärksammad på att den dövstumma
-        äldre damen höll en intressant grupp kaniner av äldre härstamning.
-        Djuren har sedan 1937 funnits i Mellerud då Ediths familj flyttade dit
-        från Stora Grimön i Vänern. Den enda kända inkorsningen av djur utifrån
-        är från 1968. Då togs två svart-vit brokiga djur, en hona och en hane,
-        in i besättningen. Djurantalet i har tidigare legat kring 15-20 men
-        minskade under de sista åren drastiskt. De sista djuren köptes ut från
-        ursprungsbesättningen under 2007.
-      </p>
-      <p>
-        I slutet av oktober 2011 godkände Jordbruksverket Föreningen
-        Gotlandskaninens avelsplan för Mellerudskanin och därmed är
-        Mellerudskaninen officiellt en svensk husdjursras. Bevarandearbete
-        organiseras av Föreningen Gotlandskaninen i ett genbankssystem. Aveln
-        sker i speciella besättningar som föreningen godkänt. Det finns ungefär
-        50 sådana besättningar för Mellerudskanin spridda över hela Sverige. De
-        rapporterar till föreningen vad som sker i besättningen och utfärdar
-        stamtavlor (genbanksintyg) för de djur som går vidare i avelsarbetet i
-        gamla eller nya besättningar.
-      </p>
-      <p>
-        Om du är intresserad av att veta mer, eller vill starta en
-        genbanksbesättning för Mellerudskanin, kontakta genbanksansvarig,
-        <a href="mailto:mellerudskanin@gotlandskaninen.se">
-          mellerudskanin@gotlandskaninen.se
-        </a>.
-      </p>
-    </Typography>
-  </div>
+  return (
+    <div className="staticMain">
+      <Typography variant="h3" className="heading">
+        Mellerudskaninen
+      </Typography>
+      <Typography variant="body1" className="pSpace">
+        <p>
+          Mellerudskaninen är en rest av den gamla svenska lantraskaninen. Den
+          fanns i en besättning hos Edith Johansson, som bodde nära Mellerud i
+          Dalsland. Kaninerna gavs därför namnet Mellerudskanin.
+        </p>
+        <p>
+          Kaninerna liknar mycket Gotlandskaninen i kroppsbyggnaden, men finns
+          bara som brokigt svartvita (holländarteckning) eller som helvita
+          (albino). Vuxna djur väger runt 3 kg, har kort päls och upprättstående
+          öron. Normalt får Mellerudskaninerna 4-6 ungar. Mellerudskaninen
+          uppfattas ofta som något lugnare än Gotlandskaninen.
+        </p>
+        <p>
+          I oktober 2001 gjordes ett första besök hos ”Edith i Sjöskogen” sedan
+          Föreningen Gotlandskaninen blivit uppmärksammad på att den dövstumma
+          äldre damen höll en intressant grupp kaniner av äldre härstamning.
+          Djuren har sedan 1937 funnits i Mellerud då Ediths familj flyttade dit
+          från Stora Grimön i Vänern. Den enda kända inkorsningen av djur
+          utifrån är från 1968. Då togs två svart-vit brokiga djur, en hona och
+          en hane, in i besättningen. Djurantalet i har tidigare legat kring
+          15-20 men minskade under de sista åren drastiskt. De sista djuren
+          köptes ut från ursprungsbesättningen under 2007.
+        </p>
+        <p>
+          I slutet av oktober 2011 godkände Jordbruksverket Föreningen
+          Gotlandskaninens avelsplan för Mellerudskanin och därmed är
+          Mellerudskaninen officiellt en svensk husdjursras. Bevarandearbete
+          organiseras av Föreningen Gotlandskaninen i ett genbankssystem. Aveln
+          sker i speciella besättningar som föreningen godkänt. Det finns
+          ungefär 50 sådana besättningar för Mellerudskanin spridda över hela
+          Sverige. De rapporterar till föreningen vad som sker i besättningen
+          och utfärdar stamtavlor (genbanksintyg) för de djur som går vidare i
+          avelsarbetet i gamla eller nya besättningar.
+        </p>
+        <p>
+          Om du är intresserad av att veta mer, eller vill starta en
+          genbanksbesättning för Mellerudskanin, kontakta genbanksansvarig,
+          <a href="mailto:mellerudskanin@gotlandskaninen.se">
+            mellerudskanin@gotlandskaninen.se
+          </a>
+          .
+        </p>
+      </Typography>
+    </div>
+  );
 }
 
 export function Medlem() {
-
-  return <div className="staticMain">
-    <Typography variant='h3' className="heading">Bli Medlem</Typography>
-    <Typography variant='body1' className="pSpace">
-      <p>
-          Vill du bli medlem i föreningen? Då kan du antingen kontakta föreningen
-          eller sätta in 200 kr på Föreningen Gotlandskaninens plusgirokonto
-          35 03 44-8. Glöm inte att uppge namn och adress.
-      </p>
-      <p>
-          Som medlem får man tre gånger om året föreningens medlemstidning Koharen
-          som innehåller information till medlemmarna, artiklar och reportage,
-          annonser samt kontaktuppgifter.
-      </p>
-    </Typography>
-  </div>
+  return (
+    <div className="staticMain">
+      <Typography variant="h3" className="heading">
+        Bli Medlem
+      </Typography>
+      <Typography variant="body1" className="pSpace">
+        <p>
+          Vill du bli medlem i föreningen? Då kan du antingen kontakta
+          föreningen eller sätta in 200 kr på Föreningen Gotlandskaninens
+          plusgirokonto 35 03 44-8. Glöm inte att uppge namn och adress.
+        </p>
+        <p>
+          Som medlem får man tre gånger om året föreningens medlemstidning
+          Koharen som innehåller information till medlemmarna, artiklar och
+          reportage, annonser samt kontaktuppgifter.
+        </p>
+      </Typography>
+    </div>
+  );
 }
 
 export function Kontakt() {
-
-  return <div className="staticMain">
-    <Typography variant='h3' className="heading">Kontakta oss</Typography>
-    <Typography variant='body1' className="pSpace">
-      <p>
-        <a href="mailto:info@gotlandskaninen.se">
-        info@gotlandskaninen.se
-        </a>
-        Kontakt med föreningen, annonser och material till hemsidan
-      </p>
-      <p>
-        <a href="mailto:gotlandskanin@gotlandskaninen.se">
-          gotlandskanin@gotlandskaninen.se
-        </a>
-        Genbanksansvarig för Gotlandskanin, kassör
-      </p>
-      <p>
-        <a href="mailto:mellerudskanin@gotlandskaninen.se">
-          mellerudskanin@gotlandskaninen.se
-        </a>
-
-        Genbanksansvarig för Mellerudskanin, vice ordförande
-      </p>
-      <p>
-        <a href="mailto:ordforande@gotlandskaninen.se">
-          ordforande@gotlandskaninen.se
-        </a>
-        Ordförande
-      </p>
-    </Typography>
-  </div>
+  return (
+    <div className="staticMain">
+      <Typography variant="h3" className="heading">
+        Kontakta oss
+      </Typography>
+      <Typography variant="body1" className="pSpace">
+        <p>
+          <a href="mailto:info@gotlandskaninen.se">info@gotlandskaninen.se</a>
+          Kontakt med föreningen, annonser och material till hemsidan
+        </p>
+        <p>
+          <a href="mailto:gotlandskanin@gotlandskaninen.se">
+            gotlandskanin@gotlandskaninen.se
+          </a>
+          Genbanksansvarig för Gotlandskanin, kassör
+        </p>
+        <p>
+          <a href="mailto:mellerudskanin@gotlandskaninen.se">
+            mellerudskanin@gotlandskaninen.se
+          </a>
+          Genbanksansvarig för Mellerudskanin, vice ordförande
+        </p>
+        <p>
+          <a href="mailto:ordforande@gotlandskaninen.se">
+            ordforande@gotlandskaninen.se
+          </a>
+          Ordförande
+        </p>
+      </Typography>
+    </div>
+  );
 }
 
 export function Footer() {
+  return (
+    <div className="footer">
+      <div className="euLogo">
+        <img src="/images/EU-flagga-Europeiska-jordbruksfonden-färg.jpg" />
+      </div>
 
-  return <div className="footer">
-    <div className="euLogo">
-      <img src='/images/EU-flagga-Europeiska-jordbruksfonden-färg.jpg'/>
+      <Typography className="euText">
+        <br></br>
+        <br></br>
+        Föreningen Gotlandskaninen får stöd från EU för att bevara Gotlands- och
+        Mellerudskanin. Stödet går till genbanksbesättningarna,
+        medlemstidningen, trycksaker, genbanksintyg, marknadsföring, kurser och
+        utbildningar, transport av värdefulla djur samt obduktioner.
+      </Typography>
+      <img src="/images/logo.png" alt="logo" className="logoImage" />
     </div>
-   
-    <Typography className="euText">
-      Föreningen Gotlandskaninen får stöd från EU för att bevara Gotlands-
-      och Mellerudskanin. Stödet går till genbanksbesättningarna,
-      medlemstidningen, trycksaker, genbanksintyg, marknadsföring, kurser och
-      utbildningar, transport av värdefulla djur samt obduktioner.
-    </Typography>
-    <div className="logoImageWrapper">
-      <img src='/images/logo.png' alt="logo" className="logoImage" />
-    </div>
-  </div>
+  );
 }
 // jscpd:ignore-end

--- a/frontend/src/static_pages.tsx
+++ b/frontend/src/static_pages.tsx
@@ -5,71 +5,16 @@
 import * as React from 'react'
 import { makeStyles } from '@material-ui/core/styles';
 import { Typography } from '@material-ui/core';
+import './style.css';
 
-const useStyles = makeStyles({
-  main: {
-    padding: '.25em 1em .5em 1em',
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  euLogo: {
-    textAlign: 'center',
-    '& img': {
-      display: 'inline',
-      height: '180px',
-    }
-  },
-  euText: {
-    margin: '10px 20px',
-    display: 'inline',
-    maxWidth: '250px',
-    fontSize: '0.65em',
-    ['@media (min-width:660px)']: {
-      fontSize: '1em',
-    },
-  },
-
-  logoImageWrapper: {
-    width: '95%',
-    textAlign: 'center',
-  },
-  logoImage: {
-    width: '20vh',
-    maxWidth: '90vw',
-    float: 'right'
-  },
-
-  footer: {
-    zIndex: -4,
-    width: '100%',
-    bottom: 0,
-    left: 0,
-    padding: '20px 40px',
-    background: 'white',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    opacity: 0.9
-  },
-  heading: {
-    marginTop: '30px',
-  },
-  pSpace: {
-    paddingBottom: '20px',
-    '& p a': {
-      paddingRight: '4px',
-    }
-  }
-});
 
 // jscpd:ignore-start
 
 export function About() {
-  const styles = useStyles();
 
-  return <div className={styles.main}>
-    <Typography variant='h3' className={styles.heading}>Föreningen</Typography>
-    <Typography variant='body1' className={styles.pSpace}>
+  return <div className="staticMain">
+    <Typography variant='h3' className="heading">Föreningen</Typography>
+    <Typography variant='body1' className="pSpace">
       <p>
         Gotlandskaninen är en rest av den gamla svenska lantraskaninen.
         På 1970-talet uppmärksammades att det fanns några gårdar på
@@ -97,11 +42,10 @@ export function About() {
 }
 
 export function Gotlandskaninen() {
-  const styles = useStyles();
 
-  return <div className={styles.main}>
-    <Typography variant='h3' className={styles.heading}>Gotlandskaninen</Typography>
-    <Typography variant='body1' className={styles.pSpace}>
+  return <div className="staticMain">
+    <Typography variant='h3' className="heading">Gotlandskaninen</Typography>
+    <Typography variant='body1' className="pSpace">
       <p>
         Gotlandskaninen är en rest av den gamla svenska lantraskaninen. På
         1970-talet uppmärksammades att det fanns några gårdar på Gotland som hade
@@ -143,11 +87,10 @@ export function Gotlandskaninen() {
 }
 
 export function Mellerudskaninen() {
-  const styles = useStyles();
 
-  return <div className={styles.main}>
-    <Typography variant='h3' className={styles.heading}>Mellerudskaninen</Typography>
-    <Typography variant='body1' className={styles.pSpace}>
+  return <div className="staticMain">
+    <Typography variant='h3' className="heading">Mellerudskaninen</Typography>
+    <Typography variant='body1' className="pSpace">
       <p>
         Mellerudskaninen är en rest av den gamla svenska lantraskaninen. Den
         fanns i en besättning hos Edith Johansson, som bodde nära Mellerud i
@@ -194,11 +137,10 @@ export function Mellerudskaninen() {
 }
 
 export function Medlem() {
-  const styles = useStyles();
 
-  return <div className={styles.main}>
-    <Typography variant='h3' className={styles.heading}>Bli Medlem</Typography>
-    <Typography variant='body1' className={styles.pSpace}>
+  return <div className="staticMain">
+    <Typography variant='h3' className="heading">Bli Medlem</Typography>
+    <Typography variant='body1' className="pSpace">
       <p>
           Vill du bli medlem i föreningen? Då kan du antingen kontakta föreningen
           eller sätta in 200 kr på Föreningen Gotlandskaninens plusgirokonto
@@ -214,11 +156,10 @@ export function Medlem() {
 }
 
 export function Kontakt() {
-  const styles = useStyles();
 
-  return <div className={styles.main}>
-    <Typography variant='h3' className={styles.heading}>Kontakta oss</Typography>
-    <Typography variant='body1' className={styles.pSpace}>
+  return <div className="staticMain">
+    <Typography variant='h3' className="heading">Kontakta oss</Typography>
+    <Typography variant='body1' className="pSpace">
       <p>
         <a href="mailto:info@gotlandskaninen.se">
         info@gotlandskaninen.se
@@ -249,21 +190,20 @@ export function Kontakt() {
 }
 
 export function Footer() {
-  const styles = useStyles();
 
-  return <div className={styles.footer}>
-    <div className={styles.euLogo}>
+  return <div className="footer">
+    <div className="euLogo">
       <img src='/images/EU-flagga-Europeiska-jordbruksfonden-färg.jpg'/>
     </div>
    
-    <Typography className={styles.euText}>
+    <Typography className="euText">
       Föreningen Gotlandskaninen får stöd från EU för att bevara Gotlands-
       och Mellerudskanin. Stödet går till genbanksbesättningarna,
       medlemstidningen, trycksaker, genbanksintyg, marknadsföring, kurser och
       utbildningar, transport av värdefulla djur samt obduktioner.
     </Typography>
-    <div className={`${styles.logoImageWrapper}`}>
-      <img src='/images/logo.png' alt="logo" className={styles.logoImage} />
+    <div className="logoImageWrapper">
+      <img src='/images/logo.png' alt="logo" className="logoImage" />
     </div>
   </div>
 }

--- a/frontend/src/static_pages.tsx
+++ b/frontend/src/static_pages.tsx
@@ -28,16 +28,28 @@ const useStyles = makeStyles({
       fontSize: '1em',
     },
   },
+
+  logoImageWrapper: {
+    width: '95%',
+    textAlign: 'center',
+  },
+  logoImage: {
+    width: '20vh',
+    maxWidth: '90vw',
+    float: 'right'
+  },
+
   footer: {
     zIndex: -4,
     width: '100%',
     bottom: 0,
     left: 0,
-    padding: '10px 20px',
+    padding: '20px 40px',
     background: 'white',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
+    opacity: 0.9
   },
   heading: {
     marginTop: '30px',
@@ -243,12 +255,16 @@ export function Footer() {
     <div className={styles.euLogo}>
       <img src='/images/EU-flagga-Europeiska-jordbruksfonden-färg.jpg'/>
     </div>
+   
     <Typography className={styles.euText}>
       Föreningen Gotlandskaninen får stöd från EU för att bevara Gotlands-
       och Mellerudskanin. Stödet går till genbanksbesättningarna,
       medlemstidningen, trycksaker, genbanksintyg, marknadsföring, kurser och
       utbildningar, transport av värdefulla djur samt obduktioner.
     </Typography>
+    <div className={`${styles.logoImageWrapper}`}>
+      <img src='/images/logo.png' alt="logo" className={styles.logoImage} />
+    </div>
   </div>
 }
 // jscpd:ignore-end

--- a/frontend/src/static_pages.tsx
+++ b/frontend/src/static_pages.tsx
@@ -209,8 +209,6 @@ export function Footer() {
       </div>
 
       <Typography className="euText">
-        <br></br>
-        <br></br>
         Föreningen Gotlandskaninen får stöd från EU för att bevara Gotlands- och
         Mellerudskanin. Stödet går till genbanksbesättningarna,
         medlemstidningen, trycksaker, genbanksintyg, marknadsföring, kurser och

--- a/frontend/src/static_pages.tsx
+++ b/frontend/src/static_pages.tsx
@@ -3,7 +3,6 @@
  */
 
 import * as React from "react";
-import { makeStyles } from "@material-ui/core/styles";
 import { Typography } from "@material-ui/core";
 import "./style.css";
 
@@ -207,7 +206,6 @@ export function Footer() {
       <div className="euLogo">
         <img src="/images/EU-flagga-Europeiska-jordbruksfonden-färg.jpg" />
       </div>
-
       <Typography className="euText">
         Föreningen Gotlandskaninen får stöd från EU för att bevara Gotlands- och
         Mellerudskanin. Stödet går till genbanksbesättningarna,

--- a/frontend/src/static_pages.tsx
+++ b/frontend/src/static_pages.tsx
@@ -212,7 +212,9 @@ export function Footer() {
         medlemstidningen, trycksaker, genbanksintyg, marknadsföring, kurser och
         utbildningar, transport av värdefulla djur samt obduktioner.
       </Typography>
-      <img src="/images/logo.png" alt="logo" className="logoImage" />
+      <div>
+        <img src="/images/logo.png" alt="logo" className="logoImage" />
+      </div>
     </div>
   );
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -140,3 +140,46 @@ list-item {
     color: #222;
   }
 }
+
+table {
+  height: 100%;
+  padding: 5px;
+  overflow-y: scroll;
+}
+
+columnLabel {
+  padding-right: 30px;
+}
+
+columnSelect {
+  z-index: 15;
+}
+
+loading {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+functionLink {
+  color: blue;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+sorted {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1;
+  margin: -1;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  top: 20;
+  width: 1;
+}
+
+search {
+  float: right;
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -141,34 +141,39 @@ list-item {
   }
 }
 
-table {
+.table {
   height: 100%;
   padding: 5px;
   overflow-y: scroll;
 }
 
-columnLabel {
+.sortedTable {
+  padding: 5px;
+  overflow-y: scroll;
+}
+
+.columnLabel {
   padding-right: 30px;
 }
 
-columnSelect {
+.columnSelect {
   z-index: 15;
 }
 
-loading {
+.loading {
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
 }
 
-functionLink {
+.functionLink {
   color: blue;
   text-decoration: underline;
   cursor: pointer;
 }
 
-sorted {
+.sorted {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1;
@@ -180,6 +185,10 @@ sorted {
   width: 1;
 }
 
-search {
+.search {
   float: right;
+}
+
+.bottomButton {
+  float: left;
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -101,7 +101,7 @@ list-item {
 }
 
 .euText {
-  margin: 10px 20px;
+  margin: 10px 10px;
   display: inline;
   font-size: 0.65em;
 }
@@ -122,7 +122,7 @@ list-item {
   background: white;
   display: flex;
   opacity: 0.9;
-  text-align: justify;
+  text-align: left;
 }
 
 .heading {
@@ -137,6 +137,7 @@ list-item {
   padding-right: 4px;
 }
 
+/* desktop */
 @media screen and (min-width: 660px) {
   .main {
     margin-left: 20px;
@@ -167,6 +168,22 @@ list-item {
     padding: 0 20px;
   }
   /* stylelint-enable */
+}
+
+@media screen and (max-width: 320px) {
+  .logoImage {
+    width: 10vh;
+    height: 10vh;
+  }
+
+  .euLogo img {
+    display: inline;
+    height: 10vh;
+  }
+
+  .euText {
+    font-size: 0.5em;
+  }
 }
 
 /* Used in filter_table.tsx, genebank_view.tsx and sorted_table.tsx ==================================== */
@@ -307,4 +324,16 @@ form {
 
 .permissionField {
   width: 200px;
+}
+
+/*  Used in field_with_permission.tsx */
+.permissionFieldExtended {
+  width: 200px;
+  margin-top: 0;
+  margin-left: 5px;
+}
+
+,
+.buttonBar {
+  padding: 5px;
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -77,7 +77,7 @@ list-item {
 
 .euLogo img {
   display: inline;
-  height: 180px;
+  height: 20vh;
 }
 
 .euText {
@@ -88,7 +88,8 @@ list-item {
 
 .logoImage {
   width: 20vh;
-  max-width: 90vw;
+  max-width: 30vw;
+  height: 20vh;
   float: right;
 }
 
@@ -101,7 +102,6 @@ list-item {
   background: white;
   display: flex;
   opacity: 0.9;
-  text-align: center;
 }
 
 .heading {
@@ -191,4 +191,72 @@ list-item {
 
 .bottomButton {
   float: left;
+}
+
+.title {
+  font-size: 1.33em;
+  font-weight: bold;
+}
+
+.animalList {
+  cursor: pointer;
+}
+
+.animalList hover {
+  color: blue;
+}
+
+.container {
+  padding: 20px;
+}
+
+form {
+  display: flex;
+  flex-direction: row;
+}
+.simpleField {
+  width: 100%;
+}
+.titleHerd {
+  font-size: 2em;
+  border-bottom: 1px solid lightgrey;
+  margin: 5px 0 20px 0;
+}
+.subheading {
+  font-size: 14;
+  border-bottom: 1px solid lightgrey;
+  margin: 20px 0 5px 0;
+}
+.formCard {
+  padding: 15px;
+  margin: 10px;
+  max-width: 450px;
+  border: 1px solid grey;
+  border-radius: 5px;
+}
+.editButton {
+  float: right;
+  margin: 20px 0 0 0;
+}
+.editLink {
+  color: blue;
+}
+
+.editLink hover {
+  color: purple;
+  cursor: pointer;
+}
+.spanTitle {
+  font-weight: bold;
+  margin-left: 20px;
+}
+.contactInfo {
+  margin-bottom: 30px;
+}
+.permissionGroup {
+  display: flex;
+  flex-direction: row;
+}
+.permissionField {
+  width: "200px";
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -5,7 +5,7 @@
   top: 0;
   width: 100%;
   height: 51px;
-  background: rgba(255;255;255;0.95);
+  background: rgba(255, 255, 255, 0.95);
   border-bottom: 1px solid #aaa;
 }
 
@@ -28,7 +28,7 @@
 
 .link {
   text-decoration: none;
-  font-family: Open Sans;
+  font-family: "Open Sans";
   color: #222;
 }
 
@@ -44,11 +44,11 @@
   color: #eee;
 }
 
-hidden {
+.hidden {
   visibility: hidden;
 }
 
-menuButton {
+.menuButton {
   height: 52px;
   font-size: 1em;
 }
@@ -126,16 +126,20 @@ list-item {
     margin-left: 20px;
     margin-right: 20px;
   }
+
   .menuButton {
     font-size: 1.2em;
   }
+
   .trigram {
     font-size: 2em;
     margin-top: -7px;
   }
+
   .euText {
     font-size: 1em;
   }
+
   .logo {
     font-size: 4em;
     color: #222;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,143 +1,143 @@
 .menu {
-  position: "fixed";
+  position: fixed;
   z-index: 100;
   left: 0;
   top: 0;
-  width: "100%";
-  height: "51px";
-  background: "rgba(255;255;255;0.95)";
-  border-bottom: "1px solid #aaa";
+  width: 100%;
+  height: 51px;
+  background: rgba(255;255;255;0.95);
+  border-bottom: 1px solid #aaa;
 }
 
 .wrapper {
-  position: "relative";
-  border-top: "1px solid white";
-  border-bottom: "1px solid white";
+  position: relative;
+  border-top: 1px solid white;
+  border-bottom: 1px solid white;
 }
 
 .main {
   opacity: 0.9;
-  position: "relative";
-  margin-top: "calc(10vh)";
-  margin-bottom: "210px";
+  position: relative;
+  margin-top: calc(10vh);
+  margin-bottom: 210px;
   margin-left: 0;
   margin-right: 0;
-  padding: "10px";
-  min-height: "calc(45vh)";
+  padding: 10px;
+  min-height: calc(45vh);
 }
 
 .link {
-  text-decoration: "none";
-  font-family: "Open Sans";
-  color: "#222";
+  text-decoration: none;
+  font-family: Open Sans;
+  color: #222;
 }
 
 .logo {
-  position: "fixed";
+  position: fixed;
   z-index: -3;
-  width: "100%";
-  text-align: "center";
-  top: "10vh";
-  justify-content: "center";
-  font-variant: "small-caps";
-  font-size: "2.5em";
-  color: "#eee";
+  width: 100%;
+  text-align: center;
+  top: 10vh;
+  justify-content: center;
+  font-variant: small-caps;
+  font-size: 2.5em;
+  color: #eee;
 }
 
 hidden {
-  visibility: "hidden";
+  visibility: hidden;
 }
 
 menuButton {
-  height: "52px";
-  font-size: "1.0em";
+  height: 52px;
+  font-size: 1em;
 }
 
 .trigram {
-  font-size: "1.8em";
-  padding-right: "7px";
-  margin-top: "-5px";
+  font-size: 1.8em;
+  padding-right: 7px;
+  margin-top: -5px;
 }
 
 list-item {
-  display: "block";
+  display: block;
 }
 
 .staticMain {
-  padding: ".25em 1em .5em 1em";
-  display: "flex";
-  flex-direction: "column";
+  padding: 0.25em 1em 0.5em 1em;
+  display: flex;
+  flex-direction: column;
 }
 
 .euLogo {
-  text-align: "center";
+  text-align: center;
 }
 
 .euLogo img {
-  display: "inline";
-  height: "180px";
+  display: inline;
+  height: 180px;
 }
 
 .euText {
-  margin: "10px 20px";
-  display: "inline";
-  max-width: "250px";
-  font-size: "0.65em";
+  margin: 10px 20px;
+  display: inline;
+  max-width: 250px;
+  font-size: 0.65em;
 }
 
 .logoImageWrapper {
-  width: "95%";
-  text-align: "center";
+  width: 95%;
+  text-align: center;
 }
 
 .logoImage {
-  width: "20vh";
-  max-width: "90vw";
-  float: "right";
+  width: 20vh;
+  max-width: 90vw;
+  float: right;
 }
 
 .footer {
   z-index: -4;
-  width: "100%";
+  width: 100%;
   bottom: 0;
   left: 0;
-  padding: "20px 40px";
-  background: "white";
-  display: "flex";
-  align-items: "center";
-  justify-content: "center";
+  padding: 20px 40px;
+  background: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   opacity: 0.9;
 }
 
 .heading {
-  margin-top: "30px";
+  margin-top: 30px;
 }
 
 .pSpace {
-  padding-bottom: "20px";
+  padding-bottom: 20px;
 }
 
 .pSpace p a {
-  padding-right: "4px";
+  padding-right: 4px;
 }
 
 @media screen and (min-width: 660px) {
   .main {
-    margin-left: "20px";
-    margin-right: "20px";
+    margin-left: 20px;
+    margin-right: 20px;
   }
   .menuButton {
-    font-size: "1.2em";
+    font-size: 1.2em;
   }
   .trigram {
-    font-size: "2.0em";
-    margin-top: "-7px";
+    font-size: 2em;
+    margin-top: -7px;
   }
   .euText {
-    font-size: "1em";
+    font-size: 1em;
   }
   .logo {
-    font-size: "4em";
-    color: "#222";
+    font-size: 4em;
+    color: #222;
   }
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,163 +1,143 @@
 .menu {
-    position: 'fixed';
-    z-index: 100;
-    left: 0;
-    top: 0;
-    width: '100%';
-    height: '51px';
-    background: 'rgba(255;255;255;0.95)';
-    border-bottom: '1px solid #aaa';
-  };
+  position: "fixed";
+  z-index: 100;
+  left: 0;
+  top: 0;
+  width: "100%";
+  height: "51px";
+  background: "rgba(255;255;255;0.95)";
+  border-bottom: "1px solid #aaa";
+}
 
-  .wrapper {
-    position: 'relative';
-    border-top: '1px solid white';
-    border-bottom: '1px solid white';
-  };
+.wrapper {
+  position: "relative";
+  border-top: "1px solid white";
+  border-bottom: "1px solid white";
+}
 
+.main {
+  opacity: 0.9;
+  position: "relative";
+  margin-top: "calc(10vh)";
+  margin-bottom: "210px";
+  margin-left: 0;
+  margin-right: 0;
+  padding: "10px";
+  min-height: "calc(45vh)";
+}
+
+.link {
+  text-decoration: "none";
+  font-family: "Open Sans";
+  color: "#222";
+}
+
+.logo {
+  position: "fixed";
+  z-index: -3;
+  width: "100%";
+  text-align: "center";
+  top: "10vh";
+  justify-content: "center";
+  font-variant: "small-caps";
+  font-size: "2.5em";
+  color: "#eee";
+}
+
+hidden {
+  visibility: "hidden";
+}
+
+menuButton {
+  height: "52px";
+  font-size: "1.0em";
+}
+
+.trigram {
+  font-size: "1.8em";
+  padding-right: "7px";
+  margin-top: "-5px";
+}
+
+list-item {
+  display: "block";
+}
+
+.staticMain {
+  padding: ".25em 1em .5em 1em";
+  display: "flex";
+  flex-direction: "column";
+}
+
+.euLogo {
+  text-align: "center";
+}
+
+.euLogo img {
+  display: "inline";
+  height: "180px";
+}
+
+.euText {
+  margin: "10px 20px";
+  display: "inline";
+  max-width: "250px";
+  font-size: "0.65em";
+}
+
+.logoImageWrapper {
+  width: "95%";
+  text-align: "center";
+}
+
+.logoImage {
+  width: "20vh";
+  max-width: "90vw";
+  float: "right";
+}
+
+.footer {
+  z-index: -4;
+  width: "100%";
+  bottom: 0;
+  left: 0;
+  padding: "20px 40px";
+  background: "white";
+  display: "flex";
+  align-items: "center";
+  justify-content: "center";
+  opacity: 0.9;
+}
+
+.heading {
+  margin-top: "30px";
+}
+
+.pSpace {
+  padding-bottom: "20px";
+}
+
+.pSpace p a {
+  padding-right: "4px";
+}
+
+@media screen and (min-width: 660px) {
   .main {
-    opacity: 0.9;
-    position: 'relative';
-    margin-top: 'calc(10vh)';
-    margin-bottom: '210px';
-    margin-left: 0;
-    margin-right: 0;
-    padding: '10px';
-    min-height: 'calc(45vh)';
-  };
-
-
-
-  .link {
-    text-decoration: 'none';
-    font-family: 'Open Sans';
-    color: '#222';
-  };
-  
-  .logo {
-    position: 'fixed';
-    z-index: -3;
-    width: '100%';
-    text-align: 'center';
-    top: '10vh';
-    justify-content: 'center';
-    font-variant: 'small-caps';
-    font-size: '2.5em';
-    color: '#eee';
-   
-  };
-
-
-  hidden
-   {
-    visibility: 'hidden';
-  };
-
-  menuButton {
-    height: '52px';
-    font-size: '1.0em';
-  };
-
-
+    margin-left: "20px";
+    margin-right: "20px";
+  }
+  .menuButton {
+    font-size: "1.2em";
+  }
   .trigram {
-    font-size: '1.8em';
-    padding-right: '7px';
-    margin-top: '-5px';
-    
-  };
-
-
-
-  list-item {
-    display: 'block';
+    font-size: "2.0em";
+    margin-top: "-7px";
   }
-
-
-  .staticMain {
-    padding: '.25em 1em .5em 1em';
-    display: 'flex';
-    flex-direction: 'column';
-  }
-
-  .euLogo {
-    text-align: 'center';
-  }
-
-  .euLogo img
-  {
-    display: 'inline';
-    height: '180px';
-  }
-
   .euText {
-    margin: '10px 20px';
-    display: 'inline';
-    max-width: '250px';
-    font-size: '0.65em';
+    font-size: "1em";
   }
-
-
-  .logoImageWrapper {
-    width: '95%';
-    text-align: 'center';
+  .logo {
+    font-size: "4em";
+    color: "#222";
   }
-
-  .logoImage {
-    width: '20vh';
-    max-width: '90vw';
-    float: 'right'
-  }
-
-  .footer {
-    z-index: -4;
-    width: '100%';
-    bottom: 0;
-    left: 0;
-    padding: '20px 40px';
-    background: 'white';
-    display: 'flex';
-    align-items: 'center';
-    justify-content: 'center';
-    opacity: 0.9
-  }
-
-  .heading {
-    margin-top: '30px';
-  }
-
-  .pSpace {
-    padding-bottom: '20px';
-  }
-
-  .pSpace p a 
-  {
-    padding-right: '4px';
-  }
-
-
-  @media screen and (min-width: 660px)
-  {
-    .main
-    {
-        margin-left: '20px';
-        margin-right: '20px';
-    } 
-    .menuButton
-    {
-        font-size: '1.2em';
-    }  
-    .trigram
-    {
-        font-size: '2.0em';
-        margin-top: '-7px';
-    }  
-    .euText
-    {
-        font-size: '1em';
-    }  
-    .logo
-    {
-        font-size: '4em';
-        color: '#222';
-    }  
-  }
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css?family=Open+Sans");
+
 .menu {
   position: fixed;
   z-index: 100;
@@ -28,7 +30,7 @@
 
 .link {
   text-decoration: none;
-  font-family: "Open Sans";
+  font-family: "Open Sans", sans-serif;
   color: #222;
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,0 +1,163 @@
+.menu {
+    position: 'fixed';
+    z-index: 100;
+    left: 0;
+    top: 0;
+    width: '100%';
+    height: '51px';
+    background: 'rgba(255;255;255;0.95)';
+    border-bottom: '1px solid #aaa';
+  };
+
+  .wrapper {
+    position: 'relative';
+    border-top: '1px solid white';
+    border-bottom: '1px solid white';
+  };
+
+  .main {
+    opacity: 0.9;
+    position: 'relative';
+    margin-top: 'calc(10vh)';
+    margin-bottom: '210px';
+    margin-left: 0;
+    margin-right: 0;
+    padding: '10px';
+    min-height: 'calc(45vh)';
+  };
+
+
+
+  .link {
+    text-decoration: 'none';
+    font-family: 'Open Sans';
+    color: '#222';
+  };
+  
+  .logo {
+    position: 'fixed';
+    z-index: -3;
+    width: '100%';
+    text-align: 'center';
+    top: '10vh';
+    justify-content: 'center';
+    font-variant: 'small-caps';
+    font-size: '2.5em';
+    color: '#eee';
+   
+  };
+
+
+  hidden
+   {
+    visibility: 'hidden';
+  };
+
+  menuButton {
+    height: '52px';
+    font-size: '1.0em';
+  };
+
+
+  .trigram {
+    font-size: '1.8em';
+    padding-right: '7px';
+    margin-top: '-5px';
+    
+  };
+
+
+
+  list-item {
+    display: 'block';
+  }
+
+
+  .staticMain {
+    padding: '.25em 1em .5em 1em';
+    display: 'flex';
+    flex-direction: 'column';
+  }
+
+  .euLogo {
+    text-align: 'center';
+  }
+
+  .euLogo img
+  {
+    display: 'inline';
+    height: '180px';
+  }
+
+  .euText {
+    margin: '10px 20px';
+    display: 'inline';
+    max-width: '250px';
+    font-size: '0.65em';
+  }
+
+
+  .logoImageWrapper {
+    width: '95%';
+    text-align: 'center';
+  }
+
+  .logoImage {
+    width: '20vh';
+    max-width: '90vw';
+    float: 'right'
+  }
+
+  .footer {
+    z-index: -4;
+    width: '100%';
+    bottom: 0;
+    left: 0;
+    padding: '20px 40px';
+    background: 'white';
+    display: 'flex';
+    align-items: 'center';
+    justify-content: 'center';
+    opacity: 0.9
+  }
+
+  .heading {
+    margin-top: '30px';
+  }
+
+  .pSpace {
+    padding-bottom: '20px';
+  }
+
+  .pSpace p a 
+  {
+    padding-right: '4px';
+  }
+
+
+  @media screen and (min-width: 660px)
+  {
+    .main
+    {
+        margin-left: '20px';
+        margin-right: '20px';
+    } 
+    .menuButton
+    {
+        font-size: '1.2em';
+    }  
+    .trigram
+    {
+        font-size: '2.0em';
+        margin-top: '-7px';
+    }  
+    .euText
+    {
+        font-size: '1em';
+    }  
+    .logo
+    {
+        font-size: '4em';
+        color: '#222';
+    }  
+  }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -102,7 +102,6 @@ list-item {
 
 .euText {
   margin: 10px 10px;
-
   display: inline;
   font-size: 0.65em;
   text-align: left;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -104,6 +104,7 @@ list-item {
   margin: 10px 10px;
   display: inline;
   font-size: 0.65em;
+  text-align: left;
 }
 
 .logoImage {
@@ -122,7 +123,6 @@ list-item {
   background: white;
   display: flex;
   opacity: 0.9;
-  text-align: left;
 }
 
 .heading {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -77,7 +77,7 @@ list-item {
 
 .euLogo img {
   display: inline;
-  height: 20vh;
+  height: 15vh;
 }
 
 .euText {
@@ -87,9 +87,9 @@ list-item {
 }
 
 .logoImage {
-  width: 20vh;
+  width: 15vh;
   max-width: 30vw;
-  height: 20vh;
+  height: 15vh;
   float: right;
 }
 
@@ -102,6 +102,7 @@ list-item {
   background: white;
   display: flex;
   opacity: 0.9;
+  text-align: center;
 }
 
 .heading {
@@ -202,7 +203,7 @@ list-item {
   cursor: pointer;
 }
 
-.animalList hover {
+.animalList:hover {
   color: blue;
 }
 
@@ -214,19 +215,23 @@ form {
   display: flex;
   flex-direction: row;
 }
+
 .simpleField {
   width: 100%;
 }
+
 .titleHerd {
   font-size: 2em;
   border-bottom: 1px solid lightgrey;
   margin: 5px 0 20px 0;
 }
+
 .subheading {
   font-size: 14;
   border-bottom: 1px solid lightgrey;
   margin: 20px 0 5px 0;
 }
+
 .formCard {
   padding: 15px;
   margin: 10px;
@@ -234,29 +239,35 @@ form {
   border: 1px solid grey;
   border-radius: 5px;
 }
+
 .editButton {
   float: right;
   margin: 20px 0 0 0;
 }
+
 .editLink {
   color: blue;
 }
 
-.editLink hover {
+.editLink:hover {
   color: purple;
   cursor: pointer;
 }
+
 .spanTitle {
   font-weight: bold;
   margin-left: 20px;
 }
+
 .contactInfo {
   margin-bottom: 30px;
 }
+
 .permissionGroup {
   display: flex;
   flex-direction: row;
 }
+
 .permissionField {
-  width: "200px";
+  width: 200px;
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -17,7 +17,7 @@ body {
   width: 100%;
 }
 
-/* Used in navigation.tsx ============================================================================ */
+/* Used in navigation.tsx ====== */
 .menu {
   position: fixed;
   z-index: 100;
@@ -29,12 +29,14 @@ body {
   border-bottom: 1px solid #aaa;
 }
 
+/* Used in navigation.tsx ====== */
 .wrapper {
   position: relative;
   border-top: 1px solid white;
   border-bottom: 1px solid white;
 }
 
+/* Used in navigation.tsx ====== */
 .main {
   opacity: 0.9;
   position: relative;
@@ -46,12 +48,14 @@ body {
   min-height: calc(45vh);
 }
 
+/* Used in navigation.tsx ====== */
 .link {
   text-decoration: none;
   font-family: "Open Sans", sans-serif;
   color: #222;
 }
 
+/* Used in static_pages.tsx ====== */
 .logo {
   position: fixed;
   z-index: -3;
@@ -68,11 +72,13 @@ body {
   visibility: hidden;
 }
 
+/* Used in navigation.tsx ====== */
 .menuButton {
   height: 52px;
   font-size: 1em;
 }
 
+/* Used in navigation.tsx ====== */
 .trigram {
   font-size: 1.8em;
   padding-right: 7px;
@@ -83,23 +89,25 @@ list-item {
   display: block;
 }
 
-/* Used in static_pages.tsx ======================================================================= */
-
+/* Used in static_pages.tsx ==== */
 .staticMain {
   padding: 0.25em 1em 0.5em 1em;
   display: flex;
   flex-direction: column;
 }
 
+/* Used in static_pages.tsx ==== */
 .euLogo {
   text-align: center;
 }
 
+/* Used in static_pages.tsx ==== */
 .euLogo img {
   display: inline;
   height: 15vh;
 }
 
+/* Used in static_pages.tsx ==== */
 .euText {
   margin: 10px 10px;
   display: inline;
@@ -107,6 +115,7 @@ list-item {
   text-align: left;
 }
 
+/* Used in static_pages.tsx ==== */
 .logoImage {
   width: 15vh;
   max-width: 30vw;
@@ -114,6 +123,7 @@ list-item {
   float: right;
 }
 
+/* Used in static_pages.tsx ==== */
 .footer {
   z-index: -4;
   width: 100%;
@@ -125,14 +135,17 @@ list-item {
   opacity: 0.9;
 }
 
+/* Used in static_pages.tsx ==== */
 .heading {
   margin-top: 30px;
 }
 
+/* Used in static_pages.tsx ==== */
 .pSpace {
   padding-bottom: 20px;
 }
 
+/* Used in static_pages.tsx ==== */
 .pSpace p a {
   padding-right: 4px;
 }
@@ -170,6 +183,7 @@ list-item {
   /* stylelint-enable */
 }
 
+/* mobile */
 @media screen and (max-width: 320px) {
   .logoImage {
     width: 10vh;
@@ -186,21 +200,20 @@ list-item {
   }
 }
 
-/* Used in filter_table.tsx, genebank_view.tsx and sorted_table.tsx ==================================== */
-
+/* Used in filter_table.tsx, genebank_view.tsx and sorted_table.tsx ==== */
 .table {
   height: 100%;
   padding: 5px;
   overflow-y: scroll;
 }
 
-/* Used in filter_table.tsx, sorted_table.tsx =========================================================== */
-
+/* Used in filter_table.tsx, sorted_table.tsx =========================== */
 .sortedTable {
   padding: 5px;
   overflow-y: scroll;
 }
 
+/* Used in filter_table.tsx, sorted_table.tsx =========================== */
 .sorted {
   border: 0;
   clip: rect(0 0 0 0);
@@ -213,8 +226,7 @@ list-item {
   width: 1;
 }
 
-/* Used in filter_table.tsx ============================================================================= */
-
+/* Used in filter_table.tsx ======= */
 .columnLabel {
   padding-right: 30px;
 }
@@ -223,6 +235,7 @@ list-item {
   z-index: 15;
 }
 
+/* Used in filter_table.tsx, genebank_view.tsx, herdview.tsx, individual_view.tsx, sorted_table.tsx =================== */
 .loading {
   display: flex;
   flex-direction: column;
@@ -230,17 +243,19 @@ list-item {
   align-items: center;
 }
 
+/* Used in filter_table.tsx ======= */
 .functionLink {
   color: blue;
   text-decoration: underline;
   cursor: pointer;
 }
 
-/* Used in filter_table.tsx =========================================================================== */
+/* Used in filter_table.tsx ===== */
 .search {
   float: right;
 }
 
+/* Used in sorted_table.tsx ======= */
 .bottomButton {
   float: left;
 }
@@ -258,33 +273,37 @@ list-item {
   color: blue;
 }
 
-/* Used in herd_view.tsx ============================================================================= */
+/* Used in herd_view.tsx ======= */
 .container {
   padding: 20px;
 }
 
-/* Used in herdForm.tsx ============================================================================== */
+/* Used in herdForm.tsx ======== */
 form {
   display: flex;
   flex-direction: row;
 }
 
+/* Used in herdForm.tsx and field_with_permission.tsx ======== */
 .simpleField {
   width: 100%;
 }
 
+/* Used in herdForm.tsx ======== */
 .titleHerd {
   font-size: 2em;
   border-bottom: 1px solid lightgrey;
   margin: 5px 0 20px 0;
 }
 
+/* Used in herdForm.tsx ======== */
 .subheading {
   font-size: 14;
   border-bottom: 1px solid lightgrey;
   margin: 20px 0 5px 0;
 }
 
+/* Used in herdForm.tsx ======== */
 .formCard {
   padding: 15px;
   margin: 10px;
@@ -293,11 +312,13 @@ form {
   border-radius: 5px;
 }
 
+/* Used in herdForm.tsx ======== */
 .editButton {
   float: right;
   margin: 20px 0 0 0;
 }
 
+/* Used in herdForm.tsx ======== */
 .editLink {
   color: blue;
 }
@@ -307,20 +328,24 @@ form {
   cursor: pointer;
 }
 
+/* Used in herdForm.tsx ======== */
 .spanTitle {
   font-weight: bold;
   margin-left: 20px;
 }
 
+/* Used in herdForm.tsx ======== */
 .contactInfo {
   margin-bottom: 30px;
 }
 
+/* Used in field_with_permission.tsx ======== */
 .permissionGroup {
   display: flex;
   flex-direction: row;
 }
 
+/* Used in herdForm.tsx ======== */
 .permissionField {
   width: 200px;
 }
@@ -332,7 +357,7 @@ form {
   margin-left: 5px;
 }
 
-,
+/*  Used in genebanks.tsx */
 .buttonBar {
   padding: 5px;
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,5 +1,23 @@
 @import url("https://fonts.googleapis.com/css?family=Open+Sans");
+@import url("https://fonts.googleapis.com/css?family=Roboto");
 
+html {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+}
+
+body {
+  font-family: "Roboto", sans-serif;
+  background: #ddd center / cover no-repeat url("/images/background.jpg") fixed;
+  margin: 0;
+  padding: 0 5px;
+  min-height: calc(100vh - 56px);
+  width: 100%;
+}
+
+/* Used in navigation.tsx ============================================================================ */
 .menu {
   position: fixed;
   z-index: 100;
@@ -65,6 +83,8 @@ list-item {
   display: block;
 }
 
+/* Used in static_pages.tsx ======================================================================= */
+
 .staticMain {
   padding: 0.25em 1em 0.5em 1em;
   display: flex;
@@ -102,7 +122,7 @@ list-item {
   background: white;
   display: flex;
   opacity: 0.9;
-  text-align: center;
+  text-align: justify;
 }
 
 .heading {
@@ -140,7 +160,16 @@ list-item {
     font-size: 4em;
     color: #222;
   }
+  /* stylelint-disable */
+  body {
+    background: #ddd center / cover no-repeat url("/images/background.jpg")
+      fixed;
+    padding: 0 20px;
+  }
+  /* stylelint-enable */
 }
+
+/* Used in filter_table.tsx, genebank_view.tsx and sorted_table.tsx ==================================== */
 
 .table {
   height: 100%;
@@ -148,10 +177,14 @@ list-item {
   overflow-y: scroll;
 }
 
+/* Used in filter_table.tsx, sorted_table.tsx =========================================================== */
+
 .sortedTable {
   padding: 5px;
   overflow-y: scroll;
 }
+
+/* Used in filter_table.tsx ============================================================================= */
 
 .columnLabel {
   padding-right: 30px;
@@ -174,6 +207,7 @@ list-item {
   cursor: pointer;
 }
 
+/* Used in filter_table.tsx and sorted_table.tsx ======================================================= */
 .sorted {
   border: 0;
   clip: rect(0 0 0 0);
@@ -186,6 +220,7 @@ list-item {
   width: 1;
 }
 
+/* Used in filter_table.tsx =========================================================================== */
 .search {
   float: right;
 }
@@ -207,10 +242,12 @@ list-item {
   color: blue;
 }
 
+/* Used in herd_view.tsx ============================================================================= */
 .container {
   padding: 20px;
 }
 
+/* Used in herdForm.tsx ============================================================================== */
 form {
   display: flex;
   flex-direction: row;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -102,6 +102,7 @@ list-item {
 
 .euText {
   margin: 10px 10px;
+
   display: inline;
   font-size: 0.65em;
   text-align: left;
@@ -201,6 +202,18 @@ list-item {
   overflow-y: scroll;
 }
 
+.sorted {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1;
+  margin: -1;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  top: 20;
+  width: 1;
+}
+
 /* Used in filter_table.tsx ============================================================================= */
 
 .columnLabel {
@@ -222,19 +235,6 @@ list-item {
   color: blue;
   text-decoration: underline;
   cursor: pointer;
-}
-
-/* Used in filter_table.tsx and sorted_table.tsx ======================================================= */
-.sorted {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1;
-  margin: -1;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  top: 20;
-  width: 1;
 }
 
 /* Used in filter_table.tsx =========================================================================== */

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -81,13 +81,7 @@ list-item {
 .euText {
   margin: 10px 20px;
   display: inline;
-  max-width: 250px;
   font-size: 0.65em;
-}
-
-.logoImageWrapper {
-  width: 95%;
-  text-align: center;
 }
 
 .logoImage {
@@ -104,9 +98,8 @@ list-item {
   padding: 20px 40px;
   background: white;
   display: flex;
-  align-items: center;
-  justify-content: center;
   opacity: 0.9;
+  text-align: center;
 }
 
 .heading {


### PR DESCRIPTION
This PR continues to work on Martins basic layout. It is quite a different layout so please take a look at it and provide your comments. You can also use the test server to access it (Since nobody is using it these days I borrowed it). Now the main pages are accessed from a menu located to the left. A background image is added to all the pages, as well as a footer, etc. A new css file is added, style.css, aiming to move css code to a single file. For a start most of the styling contained in navigation.tsx and static_pages.tsx has been moved here. 
There is much more styling in the project, almost everywhere, and because these changes affect so much pages I would rather prefer to work on them on subsequent PRs (if we decide to do it), to keep this PR small. Also because I am not sure if we really want to move all the css code to a single file. Many of these styles are used by  specific tables/components. Maybe we can use the two approaches. To put the css that affects the general appearance of the pages in the stylesheet and to keep the one related with specific components in its corresponding files. 