### PR TITLE
adjusting frontend certificate logic

### DIFF
--- a/frontend/src/data_context_global.tsx
+++ b/frontend/src/data_context_global.tsx
@@ -42,6 +42,7 @@ export interface Individual extends LimitedIndividual {
   origin_herd?: HerdNameID;
   genebank?: string;
   certificate: string | null;
+  digital_certificate?: string | null;
   birth_date: string | null;
   mother: LimitedIndividual | null;
   father: LimitedIndividual | null;

--- a/frontend/src/filter_table.tsx
+++ b/frontend/src/filter_table.tsx
@@ -389,11 +389,10 @@ export function FilterTable({
     setOrderBy(property);
   };
 
-  const createSortHandler = (property: keyof Individual) => (
-    event: React.MouseEvent<unknown>
-  ) => {
-    handleRequestSort(event, property);
-  };
+  const createSortHandler =
+    (property: keyof Individual) => (event: React.MouseEvent<unknown>) => {
+      handleRequestSort(event, property);
+    };
 
   return (
     <>
@@ -517,7 +516,9 @@ export function FilterTable({
               <Button
                 variant="contained"
                 color="primary"
-                onClick={() => popup(<IndividualAdd herdId={id} />)}
+                onClick={() =>
+                  popup(<IndividualAdd herdId={id} />, "/owner", true)
+                }
               >
                 Lägg till
               </Button>

--- a/frontend/src/individual_edit.tsx
+++ b/frontend/src/individual_edit.tsx
@@ -286,20 +286,12 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
     if (type == "paper") {
       updateField("digital_certificate", null);
     } else {
-      if (!!individual?.digital_certificate) {
+      if (individual?.digital_certificate !== null) {
         updateField("digital_certificate", null);
       }
-      if (!!individual?.certificate) {
+      if (individual?.certificate !== null) {
         updateField("certificate", null);
       }
-    }
-  };
-
-  const handleCertNumber = (number: string) => {
-    if (certType == "paper") {
-      updateField("certificate", number);
-    } else if (certType == "digital") {
-      updateField("digital_certificate", number);
     }
   };
 

--- a/frontend/src/individual_edit.tsx
+++ b/frontend/src/individual_edit.tsx
@@ -278,6 +278,13 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
       : userMessage("Något gick fel.", "error");
   }, [id]);
 
+  /**
+   * This is to make sure there never is a value in the local state for
+   * both digital and paper certificate, only for one (or none) of them.
+   * Without this, redundant values could be remaining in the state if the user
+   * changes the cert type after putting in a number.
+   *
+   */
   const onCertTypeChange = (type: string) => {
     setCertType(type);
     if (type == "digital") {

--- a/frontend/src/individual_edit.tsx
+++ b/frontend/src/individual_edit.tsx
@@ -280,6 +280,19 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
 
   const onCertTypeChange = (type: string) => {
     setCertType(type);
+    if (type == "digital") {
+      updateField("certificate", null);
+    }
+    if (type == "paper") {
+      updateField("digital_certificate", null);
+    } else {
+      if (!!individual?.digital_certificate) {
+        updateField("digital_certificate", null);
+      }
+      if (!!individual?.certificate) {
+        updateField("certificate", null);
+      }
+    }
   };
 
   const handleCertNumber = (number: string) => {
@@ -475,25 +488,42 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
                         onCertTypeChange(newValue?.value ?? "unknown")
                       }
                     />
-                    <TextField
-                      disabled={!canManage}
-                      label="Certifikatnummer"
-                      placeholder={
-                        certType == "unknown" || certType == "none"
-                          ? "Välj certifikattyp först."
-                          : ""
-                      }
-                      className={style.control}
-                      variant={inputVariant}
-                      value={
-                        individual.certificate ??
-                        individual.digital_certificate ??
-                        ""
-                      }
-                      onChange={(event) => {
-                        handleCertNumber(event.currentTarget.value);
-                      }}
-                    />
+                    {certType == "paper" ? (
+                      <TextField
+                        disabled={!canManage}
+                        label="Certifikatnummer papper"
+                        className={style.control}
+                        variant={inputVariant}
+                        value={individual.certificate ?? ""}
+                        onChange={(event) => {
+                          updateField("certificate", event.currentTarget.value);
+                        }}
+                      />
+                    ) : certType == "digital" ? (
+                      <TextField
+                        disabled={!canManage}
+                        label="Certifikatnummer digital"
+                        className={style.control}
+                        variant={inputVariant}
+                        value={individual.digital_certificate ?? ""}
+                        onChange={(event) => {
+                          updateField(
+                            "digital_certificate",
+                            event.currentTarget.value
+                          );
+                        }}
+                      />
+                    ) : (
+                      <TextField
+                        label="Certifikatnummer"
+                        disabled
+                        placeholder="Välj typ först."
+                        className={style.control}
+                        variant={inputVariant}
+                        value={"Välj certifikattyp först."}
+                        onChange={() => {}}
+                      />
+                    )}
                   </div>
                 </div>
                 <TextField

--- a/frontend/src/individual_edit.tsx
+++ b/frontend/src/individual_edit.tsx
@@ -162,6 +162,7 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
   const [individual, setIndividual] = React.useState(
     undefined as Individual | undefined
   );
+  const [certType, setCertType] = React.useState("unknown" as string);
   const [bodyfat, setBodyfat] = React.useState("normal");
   const [weight, setWeight] = React.useState(null as number | null);
   const [bodyfatDate, setBodyfatDate] = React.useState(null as string | null);
@@ -173,6 +174,13 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
     return user?.canEdit(individual?.genebank);
   }, [user, individual]);
   const style = useStyles();
+
+  const certTypeOptions: OptionType[] = [
+    { value: "digital", label: "Digital" },
+    { value: "paper", label: "Papper" },
+    { value: "none", label: "Inget" },
+    { value: "unknown", label: "Okänt" },
+  ];
 
   const sexOptions = [
     { value: "female", label: "Hona" },
@@ -259,6 +267,23 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
         )
       : userMessage("Något gick fel.", "error");
   }, [id]);
+
+  /**
+   * Set certificate type according to individual data
+   */
+  React.useEffect(() => {
+    if (!!individual?.certificate) {
+      setCertType("paper");
+    } else if (!!individual?.digital_certificate) {
+      setCertType("digital");
+    } else {
+      setCertType("none");
+    }
+  }, [individual]);
+
+  const onCertTypeChange = (type: string) => {
+    setCertType(type);
+  };
 
   /**
    * Updates a single field in `individual`.
@@ -420,14 +445,46 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
                       updateField("number", event.currentTarget.value);
                     }}
                   />
+                  <Autocomplete
+                    options={certTypeOptions ?? []}
+                    value={certTypeOptions.find(
+                      (option) =>
+                        option.value == certType ??
+                        certTypeOptions[certTypeOptions.length - 1]
+                    )}
+                    getOptionLabel={(option: OptionType) => option.label}
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        label="Certifikattyp"
+                        className={style.control}
+                        variant={inputVariant}
+                        margin="normal"
+                      />
+                    )}
+                    onChange={(event: any, newValue: OptionType) =>
+                      onCertTypeChange(newValue?.value ?? "unknown")
+                    }
+                  />
                   <TextField
                     disabled={!canManage}
                     label="Certifikat"
                     className={style.control}
                     variant={inputVariant}
-                    value={individual.certificate ?? ""}
+                    value={
+                      individual.certificate ??
+                      individual.digital_certificate ??
+                      ""
+                    }
                     onChange={(event) => {
-                      updateField("certificate", event.currentTarget.value);
+                      if (!!individual.certificate) {
+                        updateField("certificate", event.currentTarget.value);
+                      } else if (!!individual.digital_certificate) {
+                        updateField(
+                          "digital_certificate",
+                          event.currentTarget.value
+                        );
+                      }
                     }}
                   />
                 </div>

--- a/frontend/src/individual_form.tsx
+++ b/frontend/src/individual_form.tsx
@@ -184,7 +184,7 @@ export function IndividualForm({
     { value: "digital", label: "Digital" },
     { value: "paper", label: "Papper" },
     { value: "none", label: "Inget certifikat" },
-    { value: "unknown", label: "Okänt" },
+    { value: "unknown", label: "Okänd" },
   ];
 
   const sexOptions = [
@@ -214,24 +214,20 @@ export function IndividualForm({
 
   const onCertTypeChange = (type: string) => {
     setCertType(type);
-  };
-
-  const handleCertNumber = (number: string) => {
-    if (certType == "paper") {
-      onUpdateIndividual("certificate", number);
-    } else if (certType == "digital") {
-      onUpdateIndividual("digital_certificate", number);
-    }
-  };
-
-  React.useEffect(() => {
-    if (!!individual.certificate) {
-      onUpdateIndividual("digital_certificate", null);
-    }
-    if (!!individual.digital_certificate) {
+    if (type == "digital") {
       onUpdateIndividual("certificate", null);
     }
-  }, [individual.certificate, individual.digital_certificate]);
+    if (type == "paper") {
+      onUpdateIndividual("digital_certificate", null);
+    } else {
+      if (!!individual.digital_certificate) {
+        onUpdateIndividual("digital_certificate", null);
+      }
+      if (!!individual.certificate) {
+        onUpdateIndividual("certificate", null);
+      }
+    }
+  };
 
   return (
     <>
@@ -369,19 +365,35 @@ export function IndividualForm({
                           onCertTypeChange(newValue?.value ?? "unknown")
                         }
                       />
-                      <TextField
-                        label="Certifikatnummer"
-                        className={`${style.control} ${style.controlWidth}`}
-                        variant={inputVariant}
-                        value={
-                          individual.certificate ??
-                          individual.digital_certificate ??
-                          null
-                        }
-                        onChange={(event) => {
-                          handleCertNumber(event.currentTarget.value);
-                        }}
-                      />
+                      {certType == "paper" ? (
+                        <TextField
+                          label="Certifikatnummer papper"
+                          className={`${style.control} ${style.controlWidth}`}
+                          variant={inputVariant}
+                          value={individual.certificate ?? ""}
+                          onChange={(event) => {
+                            onUpdateIndividual(
+                              "certificate",
+                              event.currentTarget.value
+                            );
+                          }}
+                        />
+                      ) : certType == "digital" ? (
+                        <TextField
+                          label="Certifikatnummer digital"
+                          className={`${style.control} ${style.controlWidth}`}
+                          variant={inputVariant}
+                          value={individual.digital_certificate ?? ""}
+                          onChange={(event) => {
+                            onUpdateIndividual(
+                              "digital_certificate",
+                              event.currentTarget.value
+                            );
+                          }}
+                        />
+                      ) : (
+                        <p>Certifikatnummer - välj typ först.</p>
+                      )}
                     </div>
                   </>
                 ) : formAction == FormAction.handleCertificate ? (

--- a/frontend/src/individual_form.tsx
+++ b/frontend/src/individual_form.tsx
@@ -212,6 +212,13 @@ export function IndividualForm({
     }
   }, [individual.birth_date]);
 
+  /**
+   * This is to make sure there never is a value in the local state for
+   * both digital and paper certificate, only for one (or none) of them.
+   * Without this, redundant values could be remaining in the state if the user
+   * changes the cert type after putting in a number.
+   *
+   */
   const onCertTypeChange = (type: string) => {
     setCertType(type);
     if (type == "digital") {

--- a/frontend/src/individual_form.tsx
+++ b/frontend/src/individual_form.tsx
@@ -24,13 +24,19 @@ import { useUserContext } from "./user_context";
 const useStyles = makeStyles({
   adminPane: {
     width: "100%",
-    padding: "15px 0 5px 10px",
+    padding: "15px 10px 5px 10px",
+    marginBottom: "2em",
     border: "1px solid lightgrey",
     position: "relative",
     display: "flex",
     flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "space-between",
     background:
       "repeating-linear-gradient(135deg, white, white 25px, rgba(0,0,0,0.05) 25px, rgba(0,0,0,0.05) 50px )",
+  },
+  certNumber: {
+    margin: "0.3em",
   },
   control: {
     margin: "0.3em",
@@ -221,101 +227,131 @@ export function IndividualForm({
                       onUpdateIndividual("number", event.currentTarget.value);
                     }}
                   />
+                  {individual.digital_certificate ? (
+                    <p className={style.certNumber}>
+                      Certifikatnummer: {individual.digital_certificate}
+                    </p>
+                  ) : (
+                    <></>
+                  )}
                 </div>
               ) : (
                 <></>
               )}
               <>
-                <div className={style.flexRow}>
-                  {formAction == FormAction.AddIndividual ? ( // jscpd:ignore-start
-                    <Autocomplete
-                      options={herdOptions}
-                      noOptionsText={"Välj härstamningen först"}
-                      getOptionLabel={(option: OptionType) => option.label}
-                      className={style.controlWidth}
-                      value={
-                        herdOptions.find(
-                          (option) =>
-                            option.value.herd == individual.origin_herd?.herd
-                        ) ?? null
-                      }
-                      onChange={(event, value) =>
-                        onUpdateIndividual("origin_herd", value?.value)
-                      }
-                      renderInput={(params) => (
-                        <TextField
-                          {...params}
-                          label="Välj ursprungsbesättning"
-                          className={style.control}
-                          variant={inputVariant}
-                          margin="normal"
-                        />
-                      )}
+                {formAction == FormAction.AddIndividual ? ( // jscpd:ignore-start
+                  <>
+                    <div className={style.flexRow}>
+                      <Autocomplete
+                        options={herdOptions}
+                        noOptionsText={"Välj härstamningen först"}
+                        getOptionLabel={(option: OptionType) => option.label}
+                        className={style.controlWidth}
+                        value={
+                          herdOptions.find(
+                            (option) =>
+                              option.value.herd == individual.origin_herd?.herd
+                          ) ?? null
+                        }
+                        onChange={(event, value) =>
+                          onUpdateIndividual("origin_herd", value?.value)
+                        }
+                        renderInput={(params) => (
+                          <TextField
+                            {...params}
+                            label="Välj ursprungsbesättning"
+                            className={style.control}
+                            variant={inputVariant}
+                            margin="normal"
+                          />
+                        )}
+                      />
+
+                      <KeyboardDatePicker
+                        required
+                        error={birthDateError}
+                        autoOk
+                        variant="inline"
+                        className={`${style.control} ${style.controlWidth}`}
+                        inputVariant={inputVariant}
+                        label="Födelsedatum"
+                        format={dateFormat}
+                        value={individual.birth_date ?? null}
+                        InputLabelProps={{
+                          shrink: true,
+                        }}
+                        onChange={(date, value) => {
+                          value && onUpdateIndividual("birth_date", value);
+                        }}
+                      />
+                    </div>
+                    <div className={style.flexRow}>
+                      <TextField
+                        required
+                        error={numberError}
+                        label="Individnummer"
+                        className={`${style.control} ${style.controlWidth}`}
+                        variant={inputVariant}
+                        value={
+                          individual.number?.split("-")[1] ?? individual.number
+                        }
+                        InputProps={{
+                          startAdornment: (
+                            <InputAdornment position="start">
+                              {individual.origin_herd?.herd
+                                ? `${individual.origin_herd?.herd} -`
+                                : `${
+                                    individual.genebank
+                                      ? individual.genebank[0]
+                                      : "X"
+                                  }XXX-`}
+                            </InputAdornment>
+                          ),
+                        }}
+                        onChange={(event) => {
+                          onUpdateIndividual(
+                            "number",
+                            `${individual.origin_herd?.herd}-${event.currentTarget.value}`
+                          );
+                        }}
+                      />
+                      <TextField
+                        label="Certifikatnummer"
+                        className={`${style.control} ${style.controlWidth}`}
+                        variant={inputVariant}
+                        value={individual.certificate ?? ""}
+                        onChange={(event) => {
+                          onUpdateIndividual(
+                            "certificate",
+                            event.currentTarget.value
+                          );
+                        }}
+                      />
+                    </div>{" "}
+                  </>
+                ) : formAction == FormAction.handleCertificate ? (
+                  <div className={style.flexRow}>
+                    <KeyboardDatePicker
+                      required
+                      error={birthDateError}
+                      autoOk
+                      variant="inline"
+                      className={`${style.control} ${style.controlWidth}`}
+                      inputVariant={inputVariant}
+                      label="Födelsedatum"
+                      format={dateFormat}
+                      value={individual.birth_date ?? null}
+                      InputLabelProps={{
+                        shrink: true,
+                      }}
+                      onChange={(date, value) => {
+                        value && onUpdateIndividual("birth_date", value);
+                      }}
                     />
-                  ) : (
-                    <></>
-                  )}
-                  <KeyboardDatePicker
-                    required
-                    error={birthDateError}
-                    autoOk
-                    variant="inline"
-                    className={`${style.control} ${style.controlWidth}`}
-                    inputVariant={inputVariant}
-                    label="Födelsedatum"
-                    format={dateFormat}
-                    value={individual.birth_date ?? null}
-                    InputLabelProps={{
-                      shrink: true,
-                    }}
-                    onChange={(date, value) => {
-                      value && onUpdateIndividual("birth_date", value);
-                    }}
-                  />
-                </div>
-                <div className={style.flexRow}>
-                  <TextField
-                    required
-                    error={numberError}
-                    label="Individnummer"
-                    className={`${style.control} ${style.controlWidth}`}
-                    variant={inputVariant}
-                    value={
-                      individual.number?.split("-")[1] ?? individual.number
-                    }
-                    InputProps={{
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          {individual.origin_herd?.herd
-                            ? `${individual.origin_herd?.herd} -`
-                            : `${
-                                individual.genebank
-                                  ? individual.genebank[0]
-                                  : "X"
-                              }XXX-`}
-                        </InputAdornment>
-                      ),
-                    }}
-                    onChange={(event) => {
-                      onUpdateIndividual(
-                        "number",
-                        `${individual.origin_herd?.herd}-${event.currentTarget.value}`
-                      );
-                    }}
-                  />
-                  <TextField
-                    label="Certifikatnummer"
-                    className={`${style.control} ${style.controlWidth}`}
-                    variant={inputVariant}
-                    value={individual.certificate ?? ""}
-                    onChange={(event) => {
-                      onUpdateIndividual(
-                        "certificate",
-                        event.currentTarget.value
-                      );
-                    }}
-                  />
-                </div>
+                  </div>
+                ) : (
+                  <></>
+                )}
               </>
               <div className={style.flexRow}>
                 <TextField

--- a/frontend/src/individual_form.tsx
+++ b/frontend/src/individual_form.tsx
@@ -392,7 +392,14 @@ export function IndividualForm({
                           }}
                         />
                       ) : (
-                        <p>Certifikatnummer - välj typ först.</p>
+                        <TextField
+                          label="Certifikatnummer - välj typ först"
+                          disabled
+                          className={`${style.control} ${style.controlWidth}`}
+                          variant={inputVariant}
+                          value={null}
+                          onChange={() => {}}
+                        />
                       )}
                     </div>
                   </>

--- a/frontend/src/individual_form.tsx
+++ b/frontend/src/individual_form.tsx
@@ -220,10 +220,10 @@ export function IndividualForm({
     if (type == "paper") {
       onUpdateIndividual("digital_certificate", null);
     } else {
-      if (!!individual.digital_certificate) {
+      if (individual.digital_certificate !== null) {
         onUpdateIndividual("digital_certificate", null);
       }
-      if (!!individual.certificate) {
+      if (individual.certificate !== null) {
         onUpdateIndividual("certificate", null);
       }
     }
@@ -370,7 +370,7 @@ export function IndividualForm({
                           label="Certifikatnummer papper"
                           className={`${style.control} ${style.controlWidth}`}
                           variant={inputVariant}
-                          value={individual.certificate ?? ""}
+                          value={individual.certificate ?? null}
                           onChange={(event) => {
                             onUpdateIndividual(
                               "certificate",
@@ -383,7 +383,7 @@ export function IndividualForm({
                           label="Certifikatnummer digital"
                           className={`${style.control} ${style.controlWidth}`}
                           variant={inputVariant}
-                          value={individual.digital_certificate ?? ""}
+                          value={individual.digital_certificate ?? null}
                           onChange={(event) => {
                             onUpdateIndividual(
                               "digital_certificate",

--- a/frontend/src/individual_view.tsx
+++ b/frontend/src/individual_view.tsx
@@ -92,25 +92,9 @@ export function IndividualView({ id }: { id: string }) {
   const [certificateUrl, setCertificateUrl] = React.useState(
     undefined as string | undefined
   );
-  const [hasPaperCert, setHasPaperCert] = React.useState(false as boolean);
-  const [hasDigitalCert, setHasDigitalCert] = React.useState(false as boolean);
   // state to control the certificate menu button
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const { userMessage, popup } = useMessageContext();
-
-  //checks if the individual has a certificate, and if yes whether it's a paper or digital one
-  const getCertificateType = (individual: Individual) => {
-    if (individual.certificate === null) {
-      setHasPaperCert(false);
-      setHasDigitalCert(false);
-    } else if (parseInt(individual.certificate, 10) < 100000) {
-      setHasPaperCert(true);
-      setHasDigitalCert(false);
-    } else if (parseInt(individual.certificate, 10) >= 100000) {
-      setHasPaperCert(false);
-      setHasDigitalCert(true);
-    }
-  };
 
   // funtions to control the certificate menu button
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -204,16 +188,6 @@ export function IndividualView({ id }: { id: string }) {
     );
   }, [id]);
 
-  //show the right buttons
-  React.useEffect(() => {
-    if (individual) {
-      getCertificateType(individual);
-    } else {
-      setHasPaperCert(false);
-      setHasDigitalCert(false);
-    }
-  }, [individual]);
-
   return (
     <>
       <div className={style.body}>
@@ -297,8 +271,8 @@ export function IndividualView({ id }: { id: string }) {
                 </Button>
               )}
               {user?.canEdit(individual.origin_herd.herd) &&
-                !hasDigitalCert &&
-                !hasPaperCert && (
+                !individual.digital_certificate &&
+                !individual.certificate && (
                   <Button
                     className={style.editButton}
                     variant="contained"
@@ -312,8 +286,8 @@ export function IndividualView({ id }: { id: string }) {
                 )}
               {individual.origin_herd.herd !== individual.herd.herd &&
                 user?.canEdit(individual.herd.herd) &&
-                !hasDigitalCert &&
-                !hasPaperCert && (
+                !individual.certificate &&
+                !individual.digital_certificate && (
                   <>
                     <Button
                       className={style.editButton}
@@ -329,60 +303,61 @@ export function IndividualView({ id }: { id: string }) {
                     </p>
                   </>
                 )}
-              {user?.canEdit(individual.herd.herd) && hasDigitalCert && (
-                <>
-                  <Button
-                    aria-controls="simple-menu"
-                    aria-haspopup="true"
-                    variant="contained"
-                    color="primary"
-                    className={style.editButton}
-                    onClick={handleClick}
-                  >
-                    Certifikat{" "}
-                    <ArrowForward fontSize="small" className={style.icon} />
-                  </Button>
-                  <Menu
-                    id="simple-menu"
-                    anchorEl={anchorEl}
-                    keepMounted
-                    open={Boolean(anchorEl)}
-                    onClose={handleClose}
-                  >
-                    <MenuItem
-                      onClick={() => {
-                        handleClose();
-                        downloadCertificate();
-                      }}
+              {user?.canEdit(individual.herd.herd) &&
+                !!individual.digital_certificate && (
+                  <>
+                    <Button
+                      aria-controls="simple-menu"
+                      aria-haspopup="true"
+                      variant="contained"
+                      color="primary"
+                      className={style.editButton}
+                      onClick={handleClick}
                     >
-                      Ladda ner
-                    </MenuItem>
-                    <MenuItem
-                      onClick={() => {
-                        handleClose();
-                        popup(
-                          <IndividualCertificate id={id} action={"update"} />
-                        );
-                      }}
+                      Certifikat{" "}
+                      <ArrowForward fontSize="small" className={style.icon} />
+                    </Button>
+                    <Menu
+                      id="simple-menu"
+                      anchorEl={anchorEl}
+                      keepMounted
+                      open={Boolean(anchorEl)}
+                      onClose={handleClose}
                     >
-                      Uppdatera
-                    </MenuItem>
-                    <MenuItem
-                      onClick={() => {
-                        handleClose();
-                        popup(
-                          <CertificateVerification
-                            id={id}
-                            individual={individual}
-                          />
-                        );
-                      }}
-                    >
-                      Verifiera
-                    </MenuItem>
-                  </Menu>
-                </>
-              )}
+                      <MenuItem
+                        onClick={() => {
+                          handleClose();
+                          downloadCertificate();
+                        }}
+                      >
+                        Ladda ner
+                      </MenuItem>
+                      <MenuItem
+                        onClick={() => {
+                          handleClose();
+                          popup(
+                            <IndividualCertificate id={id} action={"update"} />
+                          );
+                        }}
+                      >
+                        Uppdatera
+                      </MenuItem>
+                      <MenuItem
+                        onClick={() => {
+                          handleClose();
+                          popup(
+                            <CertificateVerification
+                              id={id}
+                              individual={individual}
+                            />
+                          );
+                        }}
+                      >
+                        Verifiera
+                      </MenuItem>
+                    </Menu>
+                  </>
+                )}
               <div>
                 <h3>Besättningshistoria</h3>
                 <ul className={style.herdList}>


### PR DESCRIPTION
Changing the UI in individual_edit and individual_form where users can manually input a certificate number.
As there now are two properties for `certificate` and `digital_certificate` in the local state object, we need to decide in which of them to store the input, so the user can now decide this. 
To me it seemed to be the most straight forward way from a user perspective, even though I'm not happy with the amounts of code it caused. Do you have other suggestions? 

Also changing the conditional rendering rules in individual_view, but that was straight forward. 

The changes in filter_table are a layout fix for a bug we noticed (and three lines formatted by prettier for whatever reason.)