### PR TITLE
Use active property consistently

### DIFF
--- a/app/tests/test_data_access.py
+++ b/app/tests/test_data_access.py
@@ -498,7 +498,7 @@ class TestDataAccess(DatabaseTest):
                 "genebank": self.genebanks[0].name,
                 "herd_active": ind.current_herd.is_active
                 or ind.current_herd.is_active is None,
-                "active": active,
+                "is_active": active,
                 "alive": ind.death_date is None and not ind.death_note,
                 "children": len(ind.children),
             }

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -1201,7 +1201,7 @@ def get_individuals(genebank_id, user_uuid=None):
                     },
                     "genebank": i["genebank_name"],
                     "herd_active": i["herd_active"] or i["herd_active"] is None,
-                    "active": as_date(i["ht_date"]) > max_report_time
+                    "is_active": as_date(i["ht_date"]) > max_report_time
                     and (i["herd_active"] or i["herd_active"] is None)
                     and i["death_date"] is None
                     and not i["death_note"],

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -588,6 +588,23 @@ class Individual(BaseModel):
 
         return data
 
+    @property
+    def active(self):
+        """
+        Returns if an individual fullfils the requirements to be active.
+        """
+        is_active = (
+            self.is_active
+            and not self.death_date
+            and not self.death_note
+            and self.latest_herdtracking_entry
+            and (
+                self.latest_herdtracking_entry.herd_tracking_date
+                > (datetime.now() - timedelta(days=366)).date()
+            )
+        )
+        return is_active
+
     def list_info(self):
         """
         Returns the information that is to be viewed in the main individuals
@@ -619,17 +636,6 @@ class Individual(BaseModel):
             else None
         )
 
-        is_active = (
-            self.is_active
-            and not self.death_date
-            and not self.death_note
-            and self.latest_herdtracking_entry
-            and (
-                self.latest_herdtracking_entry.herd_tracking_date
-                > (datetime.now() - timedelta(days=366)).date()
-            )
-        )
-
         return {
             "id": self.id,
             "name": self.name,
@@ -637,7 +643,7 @@ class Individual(BaseModel):
             "sex": self.sex,
             "father": father,
             "mother": mother,
-            "is_active": is_active,
+            "is_active": self.active,
         }
 
     class Meta:  # pylint: disable=too-few-public-methods

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -330,7 +330,7 @@ export function BreedingForm({
         notes: "",
         herd_tracking: null,
         herd_active: true,
-        active: false,
+        is_active: false,
         alive: true,
         belly_color: null,
         eye_color: null,

--- a/frontend/src/data_context_global.tsx
+++ b/frontend/src/data_context_global.tsx
@@ -55,7 +55,7 @@ export interface Individual extends LimitedIndividual {
   bodyfat?: Array<DateBodyfat> | null;
   herd_tracking: Array<DateValue> | null;
   herd_active: boolean;
-  active: boolean;
+  is_active: boolean;
   alive: boolean;
   belly_color: string | null;
   eye_color: string | null;
@@ -215,7 +215,7 @@ export function activeIndividuals(genebank: Genebank | undefined, sex: string) {
       return [];
     }
     return genebank?.individuals.filter(
-      (i) => i.sex == sex && i.active == true
+      (i) => i.sex == sex && i.is_active == true
     );
   }, [genebank]);
 }

--- a/frontend/src/genebank_view.tsx
+++ b/frontend/src/genebank_view.tsx
@@ -34,7 +34,7 @@ export function GenebankView({ genebank }: { genebank: Genebank }) {
             filters={[
               { field: "alive", label: "Visa döda" },
               { field: "herd_active", label: "Visa inaktiva besättningar" },
-              { field: "active", label: "Visa inaktiva djur" },
+              { field: "is_active", label: "Visa inaktiva djur" },
             ]}
           />
         ) : (

--- a/frontend/src/herd_view.tsx
+++ b/frontend/src/herd_view.tsx
@@ -137,7 +137,7 @@ export function HerdView({ id }: { id: string | undefined }) {
               title={"Individer i besättningen"}
               filters={[
                 { field: "alive", label: "Visa döda" },
-                { field: "active", label: "Visa inaktiva djur" },
+                { field: "is_active", label: "Visa inaktiva djur" },
               ]}
               action={
                 user?.canEdit(id)

--- a/frontend/src/individual_view.tsx
+++ b/frontend/src/individual_view.tsx
@@ -476,7 +476,7 @@ export function IndividualView({ id }: { id: string }) {
                     <li key={child.number}>
                       <span className={style.listIcon}>
                         {child.alive
-                          ? child.active
+                          ? child.is_active
                             ? activeIcon
                             : inactiveIcon
                           : deadIcon}


### PR DESCRIPTION
The active property was not used consistently across the API and frontend. This ensures that is_active is correctly used in all scenarios.