### PR TITLE
Use herd id to check for permissions

### DIFF
--- a/app/tests/test_data_access.py
+++ b/app/tests/test_data_access.py
@@ -268,18 +268,22 @@ class TestDataAccess(DatabaseTest):
                 "number": self.individuals[0].number,
                 "certificate": "new-cert",
                 "birth_date": datetime.now() - timedelta(days=30),
+                "herd": self.herds[0].herd,
             },
             "unknown_color": {
                 "number": self.individuals[0].number,
                 "color": "ultra-beige",
+                "herd": self.herds[0].herd,
             },
             "unknown_origin": {
                 "number": self.individuals[0].number,
+                "herd": self.herds[0].herd,
                 "origin_herd": {"herd": "does-not-exist"},
             },
             "valid": {
                 "number": self.individuals[0].number,
                 "birth_date": datetime.now() - timedelta(days=30),
+                "herd": self.herds[0].herd,
             },
         }
         self.assertRaises(

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -743,7 +743,7 @@ def form_to_individual(form, user=None):
     """
 
     # check user permissions
-    if not user.can_edit(form["herd"]):
+    if not user.can_edit(form.get("herd", "")):
         raise PermissionError
 
     # check if the individual exists in the datbase

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -743,7 +743,7 @@ def form_to_individual(form, user=None):
     """
 
     # check user permissions
-    if not user.can_edit(form["number"]):
+    if not user.can_edit(form["herd"]):
         raise PermissionError
 
     # check if the individual exists in the datbase


### PR DESCRIPTION
Use herd id in the backend to check whether individual adding is allowed.