### PR TITLE
Create empty rabbits when breeding is updated

### DIFF
--- a/frontend/src/breeding_context.tsx
+++ b/frontend/src/breeding_context.tsx
@@ -10,6 +10,7 @@ export interface BreedingContext {
   updateBreeding(breedingData: Breeding): Promise<any>;
   findBreedingMatch(herdId: string, breedingData: Breeding): Promise<any>;
   modifyBreedingUpdates(updates: Breeding, breedingMatch: Breeding): Breeding;
+  checkBirthUpdate(breeding: Breeding, breedingUpdates: Breeding): number;
 }
 
 const emptyBreedingContext: BreedingContext = {
@@ -27,6 +28,9 @@ const emptyBreedingContext: BreedingContext = {
       birth_notes: "",
       litter_size: null,
     };
+  },
+  checkBirthUpdate() {
+    return 0;
   },
 };
 
@@ -188,6 +192,27 @@ export const WithBreedingContext = (props: { children: React.ReactNode }) => {
     }
     return newUpdates;
   };
+
+  /**
+   * When a breeding event is updated, this function checks if birth information was updated
+   * and how many empty individuals should be created (can be 0).
+   * @param breeding the breeding that is being updated
+   * @param breedingUpdates the updates input by the user
+   * @returns number of new individuals that should be created
+   */
+  const checkBirthUpdate = (breeding: Breeding, breedingUpdates: Breeding) => {
+    if (!(breedingUpdates.birth_date && breedingUpdates.litter_size)) {
+      return 0;
+    }
+    if (!breeding.litter_size) {
+      return breedingUpdates.litter_size;
+    }
+    if (breeding.litter_size < breedingUpdates.litter_size) {
+      return breedingUpdates.litter_size - breeding.litter_size;
+    }
+    return 0;
+  };
+
   return (
     <BreedingContext.Provider
       value={{
@@ -196,6 +221,7 @@ export const WithBreedingContext = (props: { children: React.ReactNode }) => {
         updateBreeding,
         findBreedingMatch,
         modifyBreedingUpdates,
+        checkBirthUpdate,
       }}
     >
       {props.children}

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -64,6 +64,7 @@ export function BreedingForm({
     updateBreeding,
     findBreedingMatch,
     modifyBreedingUpdates,
+    checkBirthUpdate,
   } = useBreedingContext();
   const { userMessage } = useMessageContext();
   const [formState, setFormState] = React.useState(emptyBreeding as Breeding);
@@ -173,7 +174,8 @@ export function BreedingForm({
     }
 
     if (
-      (userInput.litter_size !== null || userInput.birth_notes !== null) &&
+      (userInput.litter_size !== null ||
+        userInput.birth_notes !== (null || "")) &&
       userInput.birth_date == null
     ) {
       userMessage(
@@ -263,67 +265,65 @@ export function BreedingForm({
         breeding,
         breedingMatch
       );
-      const isBirthUpdate = !!(
-        !breedingMatch.birth_date &&
-        !!modifiedBreedingUpdates.birth_date &&
-        !!modifiedBreedingUpdates.litter_size
+      const newIndsNumber = checkBirthUpdate(
+        breedingMatch,
+        modifiedBreedingUpdates
       );
       const updatedBreeding = await updateBreeding(modifiedBreedingUpdates);
       if (!!updatedBreeding) {
         userMessage("Parningstillfället har uppdaterats.", "success");
         handleBreedingsChanged();
 
-        // if event was updated with birth information for the first time,
-        // create empty individuals
-        if (isBirthUpdate) {
-          if (!herdId) {
-            userMessage("Något gick fel", "error");
-            return;
-          }
-          const originHerdNameID: HerdNameID = {
-            herd: herdId,
-          };
-          const fatherInd: LimitedIndividual = {
-            number: breeding.father,
-          };
-          const motherInd: LimitedIndividual = {
-            number: breeding.mother,
-          };
-          const emptyIndividual: Individual = {
-            herd: herdId,
-            origin_herd: originHerdNameID,
-            genebank: genebank?.name,
-            certificate: null,
-            number: null,
-            birth_date: modifiedBreedingUpdates.birth_date,
-            father: fatherInd,
-            mother: motherInd,
-            color_note: null,
-            death_date: null,
-            death_note: null,
-            litter: null,
-            notes: "",
-            herd_tracking: null,
-            herd_active: true,
-            is_active: false,
-            alive: true,
-            belly_color: null,
-            eye_color: null,
-            claw_color: null,
-            hair_notes: "",
-            selling_date: null,
-            breeding: modifiedBreedingUpdates.id
-              ? modifiedBreedingUpdates.id
-              : 0,
-          };
-          for (let i = 0; i < breeding.litter_size; i++) {
-            await new Promise((r) => setTimeout(r, 2000));
-            status = createEmptyIndividual(emptyIndividual);
-            if (!status || status == "error") {
-              break;
-            }
+        if (newIndsNumber == 0) {
+          return;
+        }
+
+        if (!herdId) {
+          userMessage("Något gick fel", "error");
+          return;
+        }
+        const originHerdNameID: HerdNameID = {
+          herd: herdId,
+        };
+        const fatherInd: LimitedIndividual = {
+          number: breeding.father,
+        };
+        const motherInd: LimitedIndividual = {
+          number: breeding.mother,
+        };
+        const emptyIndividual: Individual = {
+          herd: herdId,
+          origin_herd: originHerdNameID,
+          genebank: genebank?.name,
+          certificate: null,
+          number: null,
+          birth_date: modifiedBreedingUpdates.birth_date,
+          father: fatherInd,
+          mother: motherInd,
+          color_note: null,
+          death_date: null,
+          death_note: null,
+          litter: null,
+          notes: "",
+          herd_tracking: null,
+          herd_active: true,
+          is_active: false,
+          alive: true,
+          belly_color: null,
+          eye_color: null,
+          claw_color: null,
+          hair_notes: "",
+          selling_date: null,
+          breeding: modifiedBreedingUpdates.id ? modifiedBreedingUpdates.id : 0,
+        };
+        for (let i = 0; i < newIndsNumber; i++) {
+          await new Promise((r) => setTimeout(r, 2000));
+          status = createEmptyIndividual(emptyIndividual);
+          if (!status || status == "error") {
+            break;
           }
         }
+
         return;
       }
     }

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -318,7 +318,7 @@ export function BreedingForm({
         };
         for (let i = 0; i < newIndsNumber; i++) {
           await new Promise((r) => setTimeout(r, 2000));
-          status = createEmptyIndividual(emptyIndividual);
+          let status = createEmptyIndividual(emptyIndividual);
           if (!status || status == "error") {
             break;
           }
@@ -398,7 +398,7 @@ export function BreedingForm({
       };
       for (let i = 0; i < breeding.litter_size; i++) {
         await new Promise((r) => setTimeout(r, 2000));
-        status = createEmptyIndividual(emptyIndividual);
+        let status = createEmptyIndividual(emptyIndividual);
         if (!status || status == "error") {
           break;
         }

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -255,6 +255,43 @@ export function BreedingForm({
 
     handleActive(breeding);
 
+    if (!herdId) {
+      userMessage("Något gick fel", "error");
+      return;
+    }
+    const originHerdNameID: HerdNameID = {
+      herd: herdId,
+    };
+    const fatherInd: LimitedIndividual = {
+      number: breeding.father,
+    };
+    const motherInd: LimitedIndividual = {
+      number: breeding.mother,
+    };
+    const individualDummy = {
+      herd: herdId,
+      origin_herd: originHerdNameID,
+      genebank: genebank?.name,
+      certificate: null,
+      number: null,
+      father: fatherInd,
+      mother: motherInd,
+      color_note: null,
+      death_date: null,
+      death_note: null,
+      litter: null,
+      notes: "",
+      herd_tracking: null,
+      herd_active: true,
+      is_active: false,
+      alive: true,
+      belly_color: null,
+      eye_color: null,
+      claw_color: null,
+      hair_notes: "",
+      selling_date: null,
+    };
+
     if (data !== "new") {
       const breedingMatch = await findBreedingMatch(herdId, breeding);
       if (!breedingMatch) {
@@ -277,43 +314,9 @@ export function BreedingForm({
         if (newIndsNumber == 0) {
           return;
         }
-
-        if (!herdId) {
-          userMessage("Något gick fel", "error");
-          return;
-        }
-        const originHerdNameID: HerdNameID = {
-          herd: herdId,
-        };
-        const fatherInd: LimitedIndividual = {
-          number: breeding.father,
-        };
-        const motherInd: LimitedIndividual = {
-          number: breeding.mother,
-        };
         const emptyIndividual: Individual = {
-          herd: herdId,
-          origin_herd: originHerdNameID,
-          genebank: genebank?.name,
-          certificate: null,
-          number: null,
+          ...individualDummy,
           birth_date: modifiedBreedingUpdates.birth_date,
-          father: fatherInd,
-          mother: motherInd,
-          color_note: null,
-          death_date: null,
-          death_note: null,
-          litter: null,
-          notes: "",
-          herd_tracking: null,
-          herd_active: true,
-          is_active: false,
-          alive: true,
-          belly_color: null,
-          eye_color: null,
-          claw_color: null,
-          hair_notes: "",
-          selling_date: null,
           breeding: modifiedBreedingUpdates.id ? modifiedBreedingUpdates.id : 0,
         };
         for (let i = 0; i < newIndsNumber; i++) {
@@ -357,43 +360,9 @@ export function BreedingForm({
     if (!!newBirth) {
       userMessage("Sparat!", "success");
       handleBreedingsChanged();
-      if (!herdId) {
-        userMessage("Något gick fel", "error");
-        return;
-      }
-
-      const originHerdNameID: HerdNameID = {
-        herd: herdId,
-      };
-      const fatherInd: LimitedIndividual = {
-        number: breeding.father,
-      };
-      const motherInd: LimitedIndividual = {
-        number: breeding.mother,
-      };
       const emptyIndividual: Individual = {
-        herd: herdId,
-        origin_herd: originHerdNameID,
-        genebank: genebank?.name,
-        certificate: null,
-        number: null,
+        ...individualDummy,
         birth_date: newBirthData.date,
-        father: fatherInd,
-        mother: motherInd,
-        color_note: null,
-        death_date: null,
-        death_note: null,
-        litter: null,
-        notes: "",
-        herd_tracking: null,
-        herd_active: true,
-        is_active: false,
-        alive: true,
-        belly_color: null,
-        eye_color: null,
-        claw_color: null,
-        hair_notes: "",
-        selling_date: null,
         breeding: newBirthData.id ? newBirthData.id : 0,
       };
       for (let i = 0; i < breeding.litter_size; i++) {


### PR DESCRIPTION
When a breeding event is updated with birth information, empty individuals are now created if needed. 
It's needed in two cases:
- if there was no birth information at all before the update
- if the litter size is updated to a higher number (example: if it's updated from 4 to 5, create one additional empty rabbit)