### PR TITLE
Body fat (etc.) fixes

### DIFF
--- a/scripts/load-gotland.sh
+++ b/scripts/load-gotland.sh
@@ -377,7 +377,7 @@ while [ "$year" -le 2019 ]; do
 done | psql --quiet
 
 # Fix up the body fat data
-cat <<-END_SQL
+psql --quiet<<-'END_SQL'
 	UPDATE	bodyfat
 	SET	bodyfat = 'low'
 	WHERE	bodyfat = 'm';

--- a/scripts/load-gotland.sh
+++ b/scripts/load-gotland.sh
@@ -376,6 +376,24 @@ while [ "$year" -le 2019 ]; do
 	year=$(( year + 1 ))
 done | psql --quiet
 
+# Fix up the body fat data
+cat <<-END_SQL
+	UPDATE	bodyfat
+	SET	bodyfat = 'low'
+	WHERE	bodyfat = 'm';
+
+	UPDATE	bodyfat
+	SET	bodyfat = 'normal'
+	WHERE	bodyfat = 'n';
+
+	UPDATE	bodyfat
+	SET	bodyfat = 'high'
+	WHERE	bodyfat = 'f';
+
+	DELETE FROM 	bodyfat
+	WHERE	bodyfat NOT IN ('low', 'normal', 'high');
+END_SQL
+
 if [ ! -f "$3" ]; then
 	# No herd info
 	exit 0

--- a/scripts/load-in-docker.sh
+++ b/scripts/load-in-docker.sh
@@ -73,10 +73,12 @@ for name in "$gfile" "$Gfile" "$mfile" "$Mfile"; do
 			if [ ! -s "$csvname" ] || [ ! -e "$csvname" ] || [ "$csvname" -ot "$name" ]
 			then
 				printf 'Converting "%s" to "%s"\n' "$name" "$csvname" >&2
-				in2csv "$name" >"$csvname"
+				in2csv "$name" |
+				grep -v -x '[[:blank:]]\{1,\}' >"$csvname"
 				if [ ! -s "$csvname" ]; then
-				    echo "in2csv failed, doing xlsx2csv instead"
-				    xlsx2csv --skipemptycolumns --ignoreempty "$name" > "$csvname"
+					echo "in2csv failed, doing xlsx2csv instead"
+					xlsx2csv --skipemptycolumns --ignoreempty "$name" |
+					grep -v -x '[[:blank:]]\{1,\}' >"$csvname"
 				fi
 			fi
 			;;


### PR DESCRIPTION
This PR fixes two things:

1. Removes any empty lines in the CSV data. This gets rid of manually added empty lines in the data that would later give rise to "duplicated entries".
2. Body fat data is no longer stored as codes taken directly from the Excel data (`low`, `normal`, `high`).


Closes issue #385.