### PR TITLE
Bug fixes: individual registration and updates

### DIFF
--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -764,21 +764,13 @@ def form_to_individual(form, user=None):
         and individual.current_herd.genebank_id in user.is_manager
     )
 
-    admin_fields = [
-        "certificate",
-        "name",
-        "sex",
-        "birth_date",
-        "color_note",
-        "mother",
-        "father",
-        "color",
-    ]
+    admin_fields = ["digital_certificate", "certificate", "number"]
     # check if a non-manager-user tries to update restricted fields
     # (owners can still set these values in new individuals)
     if individual.id and not can_manage:
         for admin_field in [field for field in admin_fields if field in form]:
-            if "number" in form[admin_field]:  # parents
+            fields = form.get(admin_field, None)
+            if fields and "number" in fields:  # parents
                 changed = (
                     form[admin_field]["number"]
                     != getattr(individual, admin_field).number

--- a/frontend/src/breeding_context.tsx
+++ b/frontend/src/breeding_context.tsx
@@ -62,7 +62,7 @@ export const WithBreedingContext = (props: { children: React.ReactNode }) => {
   /**
    * Function that can be used to create a new breeding event
    **/
-   const createBreeding = async (
+  const createBreeding = async (
     breedingData: LimitedBreeding
   ): Promise<any> => {
     const breedingEvent: {

--- a/frontend/src/breeding_context.tsx
+++ b/frontend/src/breeding_context.tsx
@@ -34,7 +34,7 @@ const emptyBreedingContext: BreedingContext = {
   },
 };
 
-export const BreedingContext = React.createContext(emptyBreedingContext);
+const BreedingContext = React.createContext(emptyBreedingContext);
 
 export const useBreedingContext = () => {
   return React.useContext(BreedingContext);
@@ -62,7 +62,7 @@ export const WithBreedingContext = (props: { children: React.ReactNode }) => {
   /**
    * Function that can be used to create a new breeding event
    **/
-  const createBreeding = async (
+   const createBreeding = async (
     breedingData: LimitedBreeding
   ): Promise<any> => {
     const breedingEvent: {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,11 +16,11 @@ const Main = (
     <BrowserRouter>
       <WithDataContext>
         <WithUserContext>
-          <WithMessageContext>
-            <WithBreedingContext>
+          <WithBreedingContext>
+            <WithMessageContext>
               <Navigation />
-            </WithBreedingContext>
-          </WithMessageContext>
+            </WithMessageContext>
+          </WithBreedingContext>
         </WithUserContext>
       </WithDataContext>
     </BrowserRouter>


### PR DESCRIPTION
- Owners could not update individuals due to being limited to some admin only attributes
- The breeding context was not being used, which led to the registration of new animals to fail
- Admin attributes have now been changed to only certificates and individual numbers