### PR TITLE
Upgrade default user roles to "Viewer"

### DIFF
--- a/app/herdbook.py
+++ b/app/herdbook.py
@@ -391,6 +391,10 @@ def external_login_handler(service):
         None,
         validated=True,
         fullname=accountdetails["fullname"] if "fullname" in accountdetails else None,
+        privileges=[
+            {"level": "viewer", "genebank": 1},
+            {"level": "viewer", "genebank": 2},
+        ],
     )
 
     if not user:

--- a/app/herdbook.py
+++ b/app/herdbook.py
@@ -225,7 +225,7 @@ def manage_roles():
     status a json status message.
     The input data should be formatted like:
         {action: add | remove,
-         role: owner | manager | specialist,
+         role: owner | manager | viewer,
          user: <id>,
          herd | genebank: <id>
         }

--- a/app/tests/database_test.py
+++ b/app/tests/database_test.py
@@ -194,11 +194,11 @@ class DatabaseTest(unittest.TestCase):
             bodyfat.save()
 
         self.admin = da.register_user("admin", "pass")
-        self.specialist = da.register_user("spec", "pass")
+        self.viewer = da.register_user("spec", "pass")
         self.manager = da.register_user("man", "pass")
         self.owner = da.register_user("owner", "pass")
         self.admin.add_role("admin", None)
-        self.specialist.add_role("specialist", self.genebanks[0].id)
+        self.viewer.add_role("viewer", self.genebanks[0].id)
         self.manager.add_role("manager", self.genebanks[0].id)
         self.owner.add_role("owner", self.herds[0].id)
 

--- a/app/tests/test_data_access.py
+++ b/app/tests/test_data_access.py
@@ -51,7 +51,7 @@ class TestDataAccess(DatabaseTest):
             {"status": "error", "message": "forbidden"},
         )
         self.assertDictEqual(
-            da.add_user(valid_form, self.specialist.uuid),
+            da.add_user(valid_form, self.viewer.uuid),
             {"status": "error", "message": "forbidden"},
         )
 
@@ -169,7 +169,7 @@ class TestDataAccess(DatabaseTest):
         """
         self.assertIsNone(da.get_genebanks("invalid-uuid"))
 
-        for user in [self.admin, self.manager, self.specialist, self.owner]:
+        for user in [self.admin, self.manager, self.viewer, self.owner]:
             for herd in self.herds:
                 value = da.get_herd(herd.herd, user.uuid)
                 target = db.Herd.get(db.Herd.herd == herd.herd).filtered_dict(user)
@@ -228,7 +228,7 @@ class TestDataAccess(DatabaseTest):
             invalid_user, {"status": "error", "message": "Not logged in"}
         )
 
-        not_permitted = da.update_herd(forms["valid"], self.specialist.uuid)
+        not_permitted = da.update_herd(forms["valid"], self.viewer.uuid)
         self.assertDictEqual(not_permitted, {"status": "error", "message": "Forbidden"})
 
         valid_owner = da.update_herd(forms["valid"], self.owner.uuid)
@@ -287,7 +287,7 @@ class TestDataAccess(DatabaseTest):
             },
         }
         self.assertRaises(
-            PermissionError, da.form_to_individual, forms["valid"], self.specialist
+            PermissionError, da.form_to_individual, forms["valid"], self.viewer
         )
         self.assertRaises(
             ValueError, da.form_to_individual, forms["invalid_number"], self.admin
@@ -346,7 +346,7 @@ class TestDataAccess(DatabaseTest):
         )
 
         self.assertEqual(
-            da.add_individual(forms["valid"], self.specialist.uuid),
+            da.add_individual(forms["valid"], self.viewer.uuid),
             {"status": "error", "message": "Forbidden"},
         )
 
@@ -391,7 +391,7 @@ class TestDataAccess(DatabaseTest):
         )
 
         self.assertEqual(
-            da.add_individual(forms["valid"], self.specialist.uuid),
+            da.add_individual(forms["valid"], self.viewer.uuid),
             {"status": "error", "message": "Forbidden"},
         )
 
@@ -554,7 +554,7 @@ class TestDataAccess(DatabaseTest):
         self.assertEqual(da.get_breeding_events("does_not_exist", self.admin.uuid), [])
         # lacking permissions
         self.assertEqual(
-            da.get_breeding_events(self.herds[2].herd, self.specialist.uuid), []
+            da.get_breeding_events(self.herds[2].herd, self.viewer.uuid), []
         )
 
         breeding = db.Breeding.get(self.breeding[-1].id)

--- a/app/tests/test_database.py
+++ b/app/tests/test_database.py
@@ -133,8 +133,8 @@ class TestDatabase(DatabaseTest):
         self.assertDictEqual(gb0_herds[0], gb0_expected[0])
         self.assertDictEqual(gb0_herds[1], gb0_expected[1])
 
-        # specialist
-        gb0_herds = self.genebanks[0].get_herds(self.specialist)
+        # viewer
+        gb0_herds = self.genebanks[0].get_herds(self.viewer)
         self.assertDictEqual(gb0_herds[0], gb0_expected[0])
         self.assertDictEqual(gb0_herds[1], gb0_expected[1])
 
@@ -200,9 +200,9 @@ class TestDatabase(DatabaseTest):
         self.assertDictEqual(h0_result, h0_expected)
         self.assertDictEqual(h1_result, h1_expected)
 
-        # specialist
-        h0_result = self.herds[0].filtered_dict(self.specialist)
-        h1_result = self.herds[1].filtered_dict(self.specialist)
+        # viewer
+        h0_result = self.herds[0].filtered_dict(self.viewer)
+        h1_result = self.herds[1].filtered_dict(self.viewer)
         self.assertDictEqual(h0_result, h0_expected)
         self.assertDictEqual(h1_result, h1_expected)
 
@@ -436,8 +436,8 @@ class TestDatabase(DatabaseTest):
             [{"level": "manager", "genebank": self.genebanks[0].id}],
         )
         self.assertListEqual(
-            self.specialist.privileges,
-            [{"level": "specialist", "genebank": self.genebanks[0].id}],
+            self.viewer.privileges,
+            [{"level": "viewer", "genebank": self.genebanks[0].id}],
         )
         self.assertListEqual(
             self.owner.privileges, [{"level": "owner", "herd": self.herds[0].id}]
@@ -449,46 +449,34 @@ class TestDatabase(DatabaseTest):
         """
         self.assertEqual(self.admin.has_role("admin"), True)
         self.assertEqual(self.manager.has_role("admin"), False)
-        self.assertEqual(self.specialist.has_role("admin"), False)
+        self.assertEqual(self.viewer.has_role("admin"), False)
         self.assertEqual(self.owner.has_role("admin"), False)
 
         self.assertEqual(self.admin.has_role("manager", self.genebanks[0].id), False)
         self.assertEqual(self.manager.has_role("manager", self.genebanks[0].id), True)
-        self.assertEqual(
-            self.specialist.has_role("manager", self.genebanks[0].id), False
-        )
+        self.assertEqual(self.viewer.has_role("manager", self.genebanks[0].id), False)
         self.assertEqual(self.owner.has_role("manager", self.genebanks[0].id), False)
         self.assertEqual(self.admin.has_role("manager", self.genebanks[1].id), False)
         self.assertEqual(self.manager.has_role("manager", self.genebanks[1].id), False)
-        self.assertEqual(
-            self.specialist.has_role("manager", self.genebanks[1].id), False
-        )
+        self.assertEqual(self.viewer.has_role("manager", self.genebanks[1].id), False)
         self.assertEqual(self.owner.has_role("manager", self.genebanks[1].id), False)
 
-        self.assertEqual(self.admin.has_role("specialist", self.genebanks[0].id), False)
-        self.assertEqual(
-            self.manager.has_role("specialist", self.genebanks[0].id), False
-        )
-        self.assertEqual(
-            self.specialist.has_role("specialist", self.genebanks[0].id), True
-        )
-        self.assertEqual(self.owner.has_role("specialist", self.genebanks[0].id), False)
-        self.assertEqual(self.admin.has_role("specialist", self.genebanks[1].id), False)
-        self.assertEqual(
-            self.manager.has_role("specialist", self.genebanks[1].id), False
-        )
-        self.assertEqual(
-            self.specialist.has_role("specialist", self.genebanks[1].id), False
-        )
-        self.assertEqual(self.owner.has_role("specialist", self.genebanks[1].id), False)
+        self.assertEqual(self.admin.has_role("viewer", self.genebanks[0].id), False)
+        self.assertEqual(self.manager.has_role("viewer", self.genebanks[0].id), False)
+        self.assertEqual(self.viewer.has_role("viewer", self.genebanks[0].id), True)
+        self.assertEqual(self.owner.has_role("viewer", self.genebanks[0].id), False)
+        self.assertEqual(self.admin.has_role("viewer", self.genebanks[1].id), False)
+        self.assertEqual(self.manager.has_role("viewer", self.genebanks[1].id), False)
+        self.assertEqual(self.viewer.has_role("viewer", self.genebanks[1].id), False)
+        self.assertEqual(self.owner.has_role("viewer", self.genebanks[1].id), False)
 
         self.assertEqual(self.admin.has_role("owner", self.herds[0].id), False)
         self.assertEqual(self.manager.has_role("owner", self.herds[0].id), False)
-        self.assertEqual(self.specialist.has_role("owner", self.herds[0].id), False)
+        self.assertEqual(self.viewer.has_role("owner", self.herds[0].id), False)
         self.assertEqual(self.owner.has_role("owner", self.herds[0].id), True)
         self.assertEqual(self.admin.has_role("owner", self.herds[1].id), False)
         self.assertEqual(self.manager.has_role("owner", self.herds[1].id), False)
-        self.assertEqual(self.specialist.has_role("owner", self.herds[1].id), False)
+        self.assertEqual(self.viewer.has_role("owner", self.herds[1].id), False)
         self.assertEqual(self.owner.has_role("owner", self.herds[1].id), False)
 
     def test_user_change_roles(self):
@@ -500,8 +488,8 @@ class TestDatabase(DatabaseTest):
         self.assertEqual(user.has_role("admin"), True)
         self.assertEqual(user.has_role("manager", self.genebanks[0].id), False)
         self.assertEqual(user.has_role("manager", self.genebanks[1].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[0].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[1].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[0].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[1].id), False)
         self.assertEqual(user.has_role("owner", self.herds[0].id), False)
         self.assertEqual(user.has_role("owner", self.herds[1].id), False)
 
@@ -509,17 +497,17 @@ class TestDatabase(DatabaseTest):
         self.assertEqual(user.has_role("admin"), True)
         self.assertEqual(user.has_role("manager", self.genebanks[0].id), True)
         self.assertEqual(user.has_role("manager", self.genebanks[1].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[0].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[1].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[0].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[1].id), False)
         self.assertEqual(user.has_role("owner", self.herds[0].id), False)
         self.assertEqual(user.has_role("owner", self.herds[1].id), False)
 
-        user.add_role("specialist", self.genebanks[1].id)
+        user.add_role("viewer", self.genebanks[1].id)
         self.assertEqual(user.has_role("admin"), True)
         self.assertEqual(user.has_role("manager", self.genebanks[0].id), True)
         self.assertEqual(user.has_role("manager", self.genebanks[1].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[0].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[1].id), True)
+        self.assertEqual(user.has_role("viewer", self.genebanks[0].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[1].id), True)
         self.assertEqual(user.has_role("owner", self.herds[0].id), False)
         self.assertEqual(user.has_role("owner", self.herds[1].id), False)
 
@@ -527,8 +515,8 @@ class TestDatabase(DatabaseTest):
         self.assertEqual(user.has_role("admin"), True)
         self.assertEqual(user.has_role("manager", self.genebanks[0].id), True)
         self.assertEqual(user.has_role("manager", self.genebanks[1].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[0].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[1].id), True)
+        self.assertEqual(user.has_role("viewer", self.genebanks[0].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[1].id), True)
         self.assertEqual(user.has_role("owner", self.herds[0].id), False)
         self.assertEqual(user.has_role("owner", self.herds[1].id), True)
 
@@ -537,32 +525,32 @@ class TestDatabase(DatabaseTest):
         self.assertEqual(user.has_role("admin"), True)
         self.assertEqual(user.has_role("manager", self.genebanks[0].id), True)
         self.assertEqual(user.has_role("manager", self.genebanks[1].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[0].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[1].id), True)
+        self.assertEqual(user.has_role("viewer", self.genebanks[0].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[1].id), True)
         self.assertEqual(user.has_role("owner", self.herds[0].id), False)
         self.assertEqual(user.has_role("owner", self.herds[1].id), False)
         user.remove_role("manager", self.genebanks[0].id)
         self.assertEqual(user.has_role("admin"), True)
         self.assertEqual(user.has_role("manager", self.genebanks[0].id), False)
         self.assertEqual(user.has_role("manager", self.genebanks[1].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[0].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[1].id), True)
+        self.assertEqual(user.has_role("viewer", self.genebanks[0].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[1].id), True)
         self.assertEqual(user.has_role("owner", self.herds[0].id), False)
         self.assertEqual(user.has_role("owner", self.herds[1].id), False)
-        user.remove_role("specialist", self.genebanks[1].id)
+        user.remove_role("viewer", self.genebanks[1].id)
         self.assertEqual(user.has_role("admin"), True)
         self.assertEqual(user.has_role("manager", self.genebanks[0].id), False)
         self.assertEqual(user.has_role("manager", self.genebanks[1].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[0].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[1].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[0].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[1].id), False)
         self.assertEqual(user.has_role("owner", self.herds[0].id), False)
         self.assertEqual(user.has_role("owner", self.herds[1].id), False)
         user.remove_role("admin")
         self.assertEqual(user.has_role("admin"), False)
         self.assertEqual(user.has_role("manager", self.genebanks[0].id), False)
         self.assertEqual(user.has_role("manager", self.genebanks[1].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[0].id), False)
-        self.assertEqual(user.has_role("specialist", self.genebanks[1].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[0].id), False)
+        self.assertEqual(user.has_role("viewer", self.genebanks[1].id), False)
         self.assertEqual(user.has_role("owner", self.herds[0].id), False)
         self.assertEqual(user.has_role("owner", self.herds[1].id), False)
 
@@ -572,7 +560,7 @@ class TestDatabase(DatabaseTest):
         """
         self.assertEqual(self.admin.is_admin, True)
         self.assertEqual(self.manager.is_admin, False)
-        self.assertEqual(self.specialist.is_admin, False)
+        self.assertEqual(self.viewer.is_admin, False)
         self.assertEqual(self.owner.is_admin, False)
 
     def test_user_is_manager(self):
@@ -581,7 +569,7 @@ class TestDatabase(DatabaseTest):
         """
         self.assertEqual(self.admin.is_manager, None)
         self.assertEqual(self.manager.is_manager, [self.genebanks[0].id])
-        self.assertEqual(self.specialist.is_manager, None)
+        self.assertEqual(self.viewer.is_manager, None)
         self.assertEqual(self.owner.is_manager, None)
 
     def test_user_is_owner(self):
@@ -590,7 +578,7 @@ class TestDatabase(DatabaseTest):
         """
         self.assertEqual(self.admin.is_owner, None)
         self.assertEqual(self.manager.is_owner, None)
-        self.assertEqual(self.specialist.is_owner, None)
+        self.assertEqual(self.viewer.is_owner, None)
         self.assertEqual(self.owner.is_owner, [self.herds[0].herd])
 
     def test_user_accessible_genebanks(self):
@@ -602,7 +590,7 @@ class TestDatabase(DatabaseTest):
             [self.genebanks[0].id, self.genebanks[1].id],
         )
         self.assertEqual(self.manager.accessible_genebanks, [self.genebanks[0].id])
-        self.assertEqual(self.specialist.accessible_genebanks, [self.genebanks[0].id])
+        self.assertEqual(self.viewer.accessible_genebanks, [self.genebanks[0].id])
         self.assertEqual(self.owner.accessible_genebanks, [self.genebanks[0].id])
 
     def test_user_frontend_data(self):
@@ -634,7 +622,7 @@ class TestDatabase(DatabaseTest):
             },
         )
         self.assertDictEqual(
-            self.specialist.frontend_data(),
+            self.viewer.frontend_data(),
             {
                 "email": "spec",
                 "username": None,
@@ -665,7 +653,7 @@ class TestDatabase(DatabaseTest):
         # object reference comparison is intentional here
         self.assertListEqual(self.admin.get_genebanks(), self.genebanks)
         self.assertListEqual(self.manager.get_genebanks(), [self.genebanks[0]])
-        self.assertListEqual(self.specialist.get_genebanks(), [self.genebanks[0]])
+        self.assertListEqual(self.viewer.get_genebanks(), [self.genebanks[0]])
         self.assertListEqual(self.owner.get_genebanks(), [self.genebanks[0]])
 
     def test_user_get_genebank(self):
@@ -682,9 +670,9 @@ class TestDatabase(DatabaseTest):
         g_0["herds"] = self.genebanks[0].get_herds(self.manager)
         self.assertDictEqual(self.manager.get_genebank(self.genebanks[0].id), g_0)
         self.assertEqual(self.manager.get_genebank(self.genebanks[1].id), None)
-        g_0["herds"] = self.genebanks[0].get_herds(self.specialist)
-        self.assertDictEqual(self.specialist.get_genebank(self.genebanks[0].id), g_0)
-        self.assertEqual(self.specialist.get_genebank(self.genebanks[1].id), None)
+        g_0["herds"] = self.genebanks[0].get_herds(self.viewer)
+        self.assertDictEqual(self.viewer.get_genebank(self.genebanks[0].id), g_0)
+        self.assertEqual(self.viewer.get_genebank(self.genebanks[1].id), None)
         g_0["herds"] = self.genebanks[0].get_herds(self.owner)
         self.assertDictEqual(self.owner.get_genebank(self.genebanks[0].id), g_0)
         self.assertEqual(self.owner.get_genebank(self.genebanks[1].id), None)
@@ -711,14 +699,14 @@ class TestDatabase(DatabaseTest):
         self.assertEqual(self.manager.can_edit("H2-2"), True)
         self.assertEqual(self.manager.can_edit("H3-3"), False)
 
-        self.assertEqual(self.specialist.can_edit("genebank1"), False)
-        self.assertEqual(self.specialist.can_edit("genebank2"), False)
-        self.assertEqual(self.specialist.can_edit("H1"), False)
-        self.assertEqual(self.specialist.can_edit("H2"), False)
-        self.assertEqual(self.specialist.can_edit("H3"), False)
-        self.assertEqual(self.specialist.can_edit("H1-1"), False)
-        self.assertEqual(self.specialist.can_edit("H2-2"), False)
-        self.assertEqual(self.specialist.can_edit("H3-3"), False)
+        self.assertEqual(self.viewer.can_edit("genebank1"), False)
+        self.assertEqual(self.viewer.can_edit("genebank2"), False)
+        self.assertEqual(self.viewer.can_edit("H1"), False)
+        self.assertEqual(self.viewer.can_edit("H2"), False)
+        self.assertEqual(self.viewer.can_edit("H3"), False)
+        self.assertEqual(self.viewer.can_edit("H1-1"), False)
+        self.assertEqual(self.viewer.can_edit("H2-2"), False)
+        self.assertEqual(self.viewer.can_edit("H3-3"), False)
 
         self.assertEqual(self.owner.can_edit("genebank1"), False)
         self.assertEqual(self.owner.can_edit("genebank2"), False)

--- a/app/tests/test_endpoints.py
+++ b/app/tests/test_endpoints.py
@@ -69,7 +69,7 @@ class TestEndpoints(FlaskTest):
         """
         Checks that `herdbook.get_user` returns the correct user.
         """
-        for test_user in [self.admin, self.manager, self.specialist, self.owner]:
+        for test_user in [self.admin, self.manager, self.viewer, self.owner]:
             user_data = {
                 "email": test_user.email,
                 "fullname": test_user.fullname,
@@ -103,7 +103,7 @@ class TestEndpoints(FlaskTest):
                         "name": u.username,
                         "fullname": u.fullname,
                     }
-                    for u in [self.admin, self.specialist, self.manager, self.owner]
+                    for u in [self.admin, self.viewer, self.manager, self.owner]
                 ],
             ),
             (
@@ -115,10 +115,10 @@ class TestEndpoints(FlaskTest):
                         "name": u.username,
                         "fullname": u.fullname,
                     }
-                    for u in [self.specialist, self.manager, self.owner]
+                    for u in [self.viewer, self.manager, self.owner]
                 ],
             ),
-            (self.specialist, None),
+            (self.viewer, None),
             (self.owner, None),
         ]
 

--- a/app/tests/test_permissions.py
+++ b/app/tests/test_permissions.py
@@ -28,12 +28,12 @@ class TestPermissions(DatabaseTest):
         self.assertTrue(self.admin.is_admin)
         self.assertEqual(self.admin.accessible_genebanks, [1, 2])
 
-    def test_specialist(self):
+    def test_viewer(self):
         """
-        Checks that the specialist role has the correct permissions.
+        Checks that the viewer role has the correct permissions.
         """
-        self.assertFalse(self.specialist.is_admin)
-        self.assertEqual(self.specialist.accessible_genebanks, [1])
+        self.assertFalse(self.viewer.is_admin)
+        self.assertEqual(self.viewer.accessible_genebanks, [1])
 
     def test_manager(self):
         """
@@ -58,8 +58,8 @@ class TestPermissions(DatabaseTest):
         genebank_ids = [g["id"] for g in da.get_genebanks(self.admin.uuid)]
         self.assertTrue(self.genebanks[0].id in genebank_ids)
         self.assertTrue(self.genebanks[1].id in genebank_ids)
-        # specialist
-        genebank_ids = [g["id"] for g in da.get_genebanks(self.specialist.uuid)]
+        # viewer
+        genebank_ids = [g["id"] for g in da.get_genebanks(self.viewer.uuid)]
         self.assertTrue(self.genebanks[0].id in genebank_ids)
         self.assertTrue(self.genebanks[1].id not in genebank_ids)
         # manager
@@ -79,9 +79,9 @@ class TestPermissions(DatabaseTest):
         # admin
         self.assertTrue(da.get_genebank(self.genebanks[0].id, self.admin.uuid))
         self.assertTrue(da.get_genebank(self.genebanks[1].id, self.admin.uuid))
-        # specialist
-        self.assertTrue(da.get_genebank(self.genebanks[0].id, self.specialist.uuid))
-        self.assertFalse(da.get_genebank(self.genebanks[1].id, self.specialist.uuid))
+        # viewer
+        self.assertTrue(da.get_genebank(self.genebanks[0].id, self.viewer.uuid))
+        self.assertFalse(da.get_genebank(self.genebanks[1].id, self.viewer.uuid))
         # manager
         self.assertTrue(da.get_genebank(self.genebanks[0].id, self.manager.uuid))
         self.assertFalse(da.get_genebank(self.genebanks[1].id, self.manager.uuid))
@@ -95,7 +95,7 @@ class TestPermissions(DatabaseTest):
         for all test users.
         """
 
-        for user in [self.admin, self.manager, self.specialist, self.owner]:
+        for user in [self.admin, self.manager, self.viewer, self.owner]:
             for herd in db.Herd.select():
 
                 value = da.get_herd(herd.herd, user.uuid)
@@ -125,18 +125,18 @@ class TestPermissions(DatabaseTest):
             ),
             {"status": "success"},
         )
-        # specialist
+        # viewer
         self.assertNotEqual(
             da.add_herd(
                 {"genebank": self.genebanks[0].id, "herd": "test3"},
-                self.specialist.uuid,
+                self.viewer.uuid,
             ),
             {"status": "success"},
         )
         self.assertNotEqual(
             da.add_herd(
                 {"genebank": self.genebanks[1].id, "herd": "test4"},
-                self.specialist.uuid,
+                self.viewer.uuid,
             ),
             {"status": "success"},
         )
@@ -176,15 +176,11 @@ class TestPermissions(DatabaseTest):
         self.assertTrue(da.get_individual(self.individuals[0].number, self.admin.uuid))
         self.assertTrue(da.get_individual(self.individuals[1].number, self.admin.uuid))
         self.assertTrue(da.get_individual(self.individuals[2].number, self.admin.uuid))
-        # specialist
-        self.assertTrue(
-            da.get_individual(self.individuals[0].number, self.specialist.uuid)
-        )
-        self.assertTrue(
-            da.get_individual(self.individuals[1].number, self.specialist.uuid)
-        )
+        # viewer
+        self.assertTrue(da.get_individual(self.individuals[0].number, self.viewer.uuid))
+        self.assertTrue(da.get_individual(self.individuals[1].number, self.viewer.uuid))
         self.assertFalse(
-            da.get_individual(self.individuals[2].number, self.specialist.uuid)
+            da.get_individual(self.individuals[2].number, self.viewer.uuid)
         )
         # manager
         self.assertTrue(
@@ -209,8 +205,8 @@ class TestPermissions(DatabaseTest):
         # admin
         user_ids = [u["id"] for u in da.get_users(self.admin.uuid)]
         self.assertEqual(user_ids, [1, 2, 3, 4])
-        # specialist
-        user_ids = da.get_users(self.specialist.uuid)
+        # viewer
+        user_ids = da.get_users(self.viewer.uuid)
         self.assertEqual(user_ids, None)
         # manager
         user_ids = [u["id"] for u in da.get_users(self.manager.uuid)]
@@ -227,22 +223,22 @@ class TestPermissions(DatabaseTest):
         # admin
         self.assertTrue(self.admin.has_role("admin"))
         self.assertFalse(self.admin.has_role("manager", 1))
-        self.assertFalse(self.admin.has_role("specialist", 1))
+        self.assertFalse(self.admin.has_role("viewer", 1))
         self.assertFalse(self.admin.has_role("owner", 1))
-        # specialist
-        self.assertFalse(self.specialist.has_role("admin"))
-        self.assertFalse(self.specialist.has_role("manager", 1))
-        self.assertTrue(self.specialist.has_role("specialist", 1))
-        self.assertFalse(self.specialist.has_role("owner", 1))
+        # viewer
+        self.assertFalse(self.viewer.has_role("admin"))
+        self.assertFalse(self.viewer.has_role("manager", 1))
+        self.assertTrue(self.viewer.has_role("viewer", 1))
+        self.assertFalse(self.viewer.has_role("owner", 1))
         # manager
         self.assertFalse(self.manager.has_role("admin"))
         self.assertTrue(self.manager.has_role("manager", 1))
-        self.assertFalse(self.manager.has_role("specialist", 1))
+        self.assertFalse(self.manager.has_role("viewer", 1))
         self.assertFalse(self.manager.has_role("owner", 1))
         # owner
         self.assertFalse(self.owner.has_role("admin"))
         self.assertFalse(self.owner.has_role("manager", 1))
-        self.assertFalse(self.owner.has_role("specialist", 1))
+        self.assertFalse(self.owner.has_role("viewer", 1))
         self.assertTrue(self.owner.has_role("owner", 1))
 
     def test_update_role(self):
@@ -263,9 +259,7 @@ class TestPermissions(DatabaseTest):
         # insufficient permissions
         operation = {"action": "add", "role": "manager", "user": 1, "genebank": 1}
         self.assertEqual(da.update_role(operation, self.owner.uuid)["status"], "error")
-        self.assertEqual(
-            da.update_role(operation, self.specialist.uuid)["status"], "error"
-        )
+        self.assertEqual(da.update_role(operation, self.viewer.uuid)["status"], "error")
         operation["genebank"] = 2
         self.assertEqual(
             da.update_role(operation, self.manager.uuid)["status"], "error"
@@ -328,17 +322,17 @@ class TestPermissions(DatabaseTest):
         self.assertEqual(self.manager.can_edit(self.individuals[1].number), True)
         self.assertEqual(self.manager.can_edit(self.individuals[2].number), False)
 
-        # Specialist
-        self.assertEqual(self.specialist.can_edit(self.genebanks[0].name), False)
-        self.assertEqual(self.specialist.can_edit(self.genebanks[1].name), False)
+        # viewer
+        self.assertEqual(self.viewer.can_edit(self.genebanks[0].name), False)
+        self.assertEqual(self.viewer.can_edit(self.genebanks[1].name), False)
 
-        self.assertEqual(self.specialist.can_edit(self.herds[0].herd), False)
-        self.assertEqual(self.specialist.can_edit(self.herds[1].herd), False)
-        self.assertEqual(self.specialist.can_edit(self.herds[2].herd), False)
+        self.assertEqual(self.viewer.can_edit(self.herds[0].herd), False)
+        self.assertEqual(self.viewer.can_edit(self.herds[1].herd), False)
+        self.assertEqual(self.viewer.can_edit(self.herds[2].herd), False)
 
-        self.assertEqual(self.specialist.can_edit(self.individuals[0].number), False)
-        self.assertEqual(self.specialist.can_edit(self.individuals[1].number), False)
-        self.assertEqual(self.specialist.can_edit(self.individuals[2].number), False)
+        self.assertEqual(self.viewer.can_edit(self.individuals[0].number), False)
+        self.assertEqual(self.viewer.can_edit(self.individuals[1].number), False)
+        self.assertEqual(self.viewer.can_edit(self.individuals[2].number), False)
 
         # Owner
         self.assertEqual(self.owner.can_edit(self.genebanks[0].name), False)

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -73,6 +73,10 @@ def add_user(form, user_uuid=None):
     password = form.get("password", None)
     username = form.get("username", None)
     validated = form.get("validated", False)
+    privileges = [
+        {"level": "viewer", "genebank": 1},
+        {"level": "viewer", "genebank": 2},
+    ]
     if not email or not password:
         return {"status": "error", "message": "missing data"}
 
@@ -80,7 +84,7 @@ def add_user(form, user_uuid=None):
         if User.select().where(User.email == email).first():
             return {"status": "error", "message": "already exists"}
 
-    user = register_user(email, password, username, validated)
+    user = register_user(email, password, username, validated, privileges)
     return {"status": "created", "data": user.id}
 
 

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -483,7 +483,7 @@ def update_role(operation, user_uuid=None):
 
     The input data should be formatted like:
         {action: add | remove,
-         role: owner | manager | specialist,
+         role: owner | manager | viewer,
          user: <id>,
          herd | genebank: <id>
         }
@@ -512,10 +512,9 @@ def update_role(operation, user_uuid=None):
     ):
         valid = False
     elif (
-        operation.get("role", {}) not in ["owner", "manager", "specialist"]
+        operation.get("role", {}) not in ["owner", "manager", "viewer"]
         or (
-            operation["role"] in ["manager", "specialist"]
-            and not operation.get("genebank")
+            operation["role"] in ["manager", "viewer"] and not operation.get("genebank")
         )
         or (operation["role"] in ["owner"] and not operation.get("herd"))
     ):

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -271,7 +271,7 @@ class Herd(BaseModel):
             access_level = "private"
         elif user:
             for role in user.privileges:
-                if role["level"] in ["specialist", "manager"]:
+                if role["level"] in ["viewer", "manager"]:
                     if role["genebank"] == self.genebank.id:
                         access_level = "private"
                         break
@@ -733,7 +733,7 @@ class User(BaseModel, UserMixin):
         The privileges are a list of roles, formatted as:
         [
             {'level': 'admin'} |
-            {'level': 'specialist' | 'manager', 'genebank': id} |
+            {'level': 'viewer' | 'manager', 'genebank': id} |
             {'level': 'owner', 'herd': id}
         ]
         """
@@ -765,17 +765,17 @@ class User(BaseModel, UserMixin):
         Add `level` with `target_id` to the user privilege list. Allowed
         level/target_id combinations are:
             - level: admin, (no target)
-            - level: specialist, genebank: target_id
+            - level: viewer, genebank: target_id
             - level: manager, genebank: target_id
             - level: owner, herd: target_id
         """
 
         privs = self.privileges
-        if level not in ["admin", "specialist", "manager", "owner"]:
+        if level not in ["admin", "viewer", "manager", "owner"]:
             logging.error("Unknown role level %s", level)
             return
         role = {"level": level}
-        if level in ["specialist", "manager"]:
+        if level in ["viewer", "manager"]:
             role["genebank"] = target_id
         elif level == "owner":
             role["herd"] = target_id
@@ -790,7 +790,7 @@ class User(BaseModel, UserMixin):
 
         Allowed level/target_id combinations are:
             - level: admin, (no target)
-            - level: specialist, genebank: target_id
+            - level: viewer, genebank: target_id
             - level: manager, genebank: target_id
             - level: owner, herd: target_id
         """
@@ -798,7 +798,7 @@ class User(BaseModel, UserMixin):
             if role["level"] == level:
                 if level == "admin":
                     return True
-                if level in ["specialist", "manager"] and target_id == role["genebank"]:
+                if level in ["viewer", "manager"] and target_id == role["genebank"]:
                     return True
                 if level == "owner" and target_id == role["herd"]:
                     return True
@@ -811,7 +811,7 @@ class User(BaseModel, UserMixin):
 
         Allowed level/target_id combinations are:
             - level: admin, (no target)
-            - level: specialist, genebank: target_id
+            - level: viewer, genebank: target_id
             - level: manager, genebank: target_id
             - level: owner, herd: target_id
         """
@@ -820,7 +820,7 @@ class User(BaseModel, UserMixin):
             if role["level"] == level:
                 if level == "admin":
                     continue
-                if level in ["specialist", "manager"] and target_id == role["genebank"]:
+                if level in ["viewer", "manager"] and target_id == role["genebank"]:
                     continue
                 if level == "owner" and target_id == role["herd"]:
                     continue
@@ -869,7 +869,7 @@ class User(BaseModel, UserMixin):
             return [g.id for g in Genebank(database=DATABASE).select()]
         has_access = []
         for role in self.privileges:
-            if role["level"] in ["specialist", "manager"]:
+            if role["level"] in ["viewer", "manager"]:
                 has_access += [role["genebank"]]
             elif role["level"] == "owner":
                 herd = Herd.get(role["herd"])

--- a/frontend/src/userForm.tsx
+++ b/frontend/src/userForm.tsx
@@ -80,7 +80,7 @@ const defaultValues: ManagedUser = {
 const PermissionLevels = [
   { value: "owner", label: "Owner" },
   { value: "manager", label: "Manager" },
-  { value: "specialist", label: "Genetic Specialist" },
+  { value: "viewer", label: "Viewer" },
 ];
 /**
  * Provides a form for changing user metadata and user roles. The form will
@@ -233,7 +233,7 @@ export function UserForm({ id }: { id: number | "new" | undefined }) {
   type Operation = { action: "remove" | "add"; user: number | "new" };
   type HerdOperation = Operation & { role: "owner"; herd: number };
   type GenebankOperation = Operation & {
-    role: "manager" | "specialist";
+    role: "manager" | "viewer";
     genebank: number | undefined;
   };
   const updateRole = (operation: HerdOperation | GenebankOperation) => {


### PR DESCRIPTION
- The specialist role has been renamed to viewer because they both have the same privileges
- Users authenticated with Google will have the viewer role to the two genbanks by default