### PR TITLE
Allow only selecting the mother's herd

### DIFF
--- a/frontend/src/individual_form.tsx
+++ b/frontend/src/individual_form.tsx
@@ -155,7 +155,6 @@ export function IndividualForm({
         if (!father) {
           return;
         }
-        herds.push(father.herd);
       }
       if (individual.mother?.number) {
         mother = await get(`/api/individual/${individual.mother?.number}`);


### PR DESCRIPTION
This change removes the father's herd from the pool of options to select the herd of origin.