### PR TITLE
Allow managers to create herds

### DIFF
--- a/frontend/src/herdForm.tsx
+++ b/frontend/src/herdForm.tsx
@@ -35,7 +35,7 @@ import { FieldWithPermission, LimitedInputType } from "@app/field_with_permissio
 
 const defaultValues: Herd = {
   id: -1,
-  genebank: -1,
+  genebank: 1,
   herd: "",
   herd_name: "",
   has_details: false,
@@ -252,7 +252,7 @@ export function HerdForm({
     <>
       {(loading && <h2>Loading...</h2>) || (
         <>
-          {change && user?.canEdit(herd.herd) && (
+          {change && (user.canEdit(herd.herd) || user.canEdit(herd.genebank)) && (
             <div className="editButton">
               [{" "}
               <a
@@ -267,9 +267,9 @@ export function HerdForm({
             </div>
           )}
           <h1 className="titleHerd">
-            {herd ? `Besättning ${herdLabel(herd)}` : `Ny Besättning`}
+            {herd.herd ? `Besättning ${herdLabel(herd)}` : `Ny Besättning`}
           </h1>
-          {(currentView == "form" && user && user.canEdit(herd.herd) && (
+          {(currentView == "form" && user && (user.canEdit(herd.herd) || user.canEdit(herd.genebank)) && (
             <>
               <form className="herdForm">
                 <MuiPickersUtilsProvider utils={DateFnsUtils}>

--- a/frontend/src/user_context.tsx
+++ b/frontend/src/user_context.tsx
@@ -117,8 +117,10 @@ export function WithUserContext(props: { children: React.ReactNode }) {
       }
     }
     // id is a genebank
-    else if (genebanks.find((genebank) => genebank.name == id)) {
-      const genebank = genebanks.find((genebank) => genebank.name == id);
+    else if (genebanks.find((genebank) => genebank.id.toString() == id)) {
+      const genebank = genebanks.find(
+        (genebank) => genebank.id.toString() == id
+      );
       // you can edit if you are manager of the genebank
       if (genebank && user.is_manager?.includes(+genebank.id)) {
         return true;


### PR DESCRIPTION
- Added a check for managers to be able to create herds based on whether they have access to the genbank
- Tuned a bit the canEdit function so that it checks for the genbank id instead of the name
- Fixed default label shown for new herd creation