### PR TITLE
Yearly report and reporting as dead

### DIFF
--- a/frontend/src/data_context_global.tsx
+++ b/frontend/src/data_context_global.tsx
@@ -67,6 +67,8 @@ export interface Individual extends LimitedIndividual {
   hair_notes: string;
   selling_date: string | null;
   breeding: number | null;
+  butchered: boolean;
+  castration_date: string | null;
 }
 
 export type PrivacyLevel = "private" | "authenticated" | "public" | null;

--- a/frontend/src/individual_death.tsx
+++ b/frontend/src/individual_death.tsx
@@ -112,7 +112,7 @@ export const IndividualDeath = ({ individual }: { individual: Individual }) => {
   const onSave = () => {
     if (!isDead) {
       userMessage(
-        "Fyll i formen först. Har kaninen inte dött, tryck 'STÄNG'",
+        "Fyll i alla obligatoriska fält. Har kaninen inte dött, tryck 'STÄNG'",
         "warning"
       );
       return;
@@ -142,11 +142,12 @@ export const IndividualDeath = ({ individual }: { individual: Individual }) => {
           <>
             <div className={style.formContainer}>
               <FormControl component="fieldset">
-                <FormLabel component="legend">
+                <FormLabel component="legend" required>
                   Har kaninen dött under året?
                 </FormLabel>
                 <RadioGroup
                   row
+                  aria-required
                   aria-label="death"
                   value={isDead}
                   onChange={() => setIsDead(!isDead)}
@@ -166,6 +167,7 @@ export const IndividualDeath = ({ individual }: { individual: Individual }) => {
               <MuiPickersUtilsProvider utils={DateFnsUtils}>
                 <KeyboardDatePicker
                   autoOk
+                  required
                   disabled={!isDead}
                   disableFuture
                   minDate={minDate}
@@ -185,11 +187,12 @@ export const IndividualDeath = ({ individual }: { individual: Individual }) => {
                 />
               </MuiPickersUtilsProvider>
               <FormControl component="fieldset">
-                <FormLabel component="legend">
+                <FormLabel component="legend" required>
                   Har kaninen slaktats (t.ex. för kött, pga platsbrist e.d.)
                 </FormLabel>
                 <RadioGroup
                   row
+                  aria-required
                   aria-label="butchered"
                   value={deadIndividual.butchered ?? false}
                   onChange={() =>

--- a/frontend/src/individual_death.tsx
+++ b/frontend/src/individual_death.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+
+import { Individual, inputVariant } from "@app/data_context_global";
+import {
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  makeStyles,
+  Radio,
+  RadioGroup,
+  TextField,
+  Typography,
+} from "@material-ui/core";
+import {
+  MuiPickersUtilsProvider,
+  KeyboardDatePicker,
+} from "@material-ui/pickers";
+import DateFnsUtils from "@date-io/date-fns";
+
+const useStyles = makeStyles({
+  wideControl: {
+    margin: "5px 0",
+    minWidth: "195px",
+    width: "100%",
+    paddingRight: "5px",
+  },
+});
+
+const IndividualDeath = ({ individual }: { individual: Individual }) => {
+  const [deadIndividual, setDeadIndividual] = React.useState(
+    individual as Individual
+  );
+  const [isDead, setIsDead] = React.useState(false);
+  const style = useStyles();
+
+  /**
+   * Updates a single field in `deadIndividual`.
+   *
+   * @param field field name to update
+   * @param value the new value of the field
+   */
+  const handleUpdateIndividual = <T extends keyof Individual>(
+    field: T,
+    value: Individual[T]
+  ) => {
+    deadIndividual && setDeadIndividual({ ...deadIndividual, [field]: value });
+  };
+  return (
+    <>
+      <FormControl component="fieldset">
+        <FormLabel component="legend">Har kaninen dött under året?</FormLabel>
+        <RadioGroup
+          row
+          aria-label="death"
+          value={isDead}
+          onChange={() => setIsDead(!isDead)}
+        >
+          <FormControlLabel value={false} control={<Radio />} label="Nej" />
+          <FormControlLabel value={true} control={<Radio />} label="Ja" />
+        </RadioGroup>
+      </FormControl>
+      <MuiPickersUtilsProvider utils={DateFnsUtils}>
+        <KeyboardDatePicker
+          autoOk
+          disabled={!isDead}
+          disableFuture
+          /*                 minDate={new Date(individual.herd_tracking[0].date)}
+                minDateMessage="Datumet måste ligga efter senaste rapporteringsdatumet." */
+          fullWidth={true}
+          variant="inline"
+          inputVariant="outlined"
+          label="Dödsdatum"
+          format="yyyy-MM-dd"
+          value={deadIndividual.death_date ?? null}
+          InputLabelProps={{
+            shrink: true,
+          }}
+          onChange={(event, newValue) => {
+            newValue && handleUpdateIndividual("death_date", newValue);
+          }}
+        />
+      </MuiPickersUtilsProvider>
+      <FormControl component="fieldset">
+        <FormLabel component="legend">
+          Har kaninen slaktats (t.ex. för kött, pga platsbrist e.d.)
+        </FormLabel>
+        <RadioGroup
+          row
+          aria-label="butchered"
+          value={deadIndividual.butchered ?? false}
+          onChange={() =>
+            handleUpdateIndividual("butchered", !deadIndividual.butchered)
+          }
+        >
+          <FormControlLabel
+            value={false}
+            control={<Radio disabled={!isDead} />}
+            label="Nej"
+          />
+          <FormControlLabel
+            value={true}
+            control={<Radio disabled={!isDead} />}
+            label="Ja"
+          />
+        </RadioGroup>
+      </FormControl>
+      <TextField
+        label="Anteckningar om kaninens död"
+        disabled={!isDead}
+        variant={inputVariant}
+        className={style.wideControl}
+        multiline
+        rows={2}
+        value={deadIndividual.death_note ?? ""}
+        onChange={(event) => {
+          handleUpdateIndividual("death_note", event.currentTarget.value);
+        }}
+      />
+    </>
+  );
+};

--- a/frontend/src/individual_report.tsx
+++ b/frontend/src/individual_report.tsx
@@ -14,7 +14,12 @@ import {
   TextField,
   Typography,
 } from "@material-ui/core";
-import { CheckCircle, ExpandMore, ExpandLess } from "@material-ui/icons";
+import {
+  CheckCircle,
+  ExpandMore,
+  ExpandLess,
+  NavigateNext,
+} from "@material-ui/icons";
 import {
   MuiPickersUtilsProvider,
   KeyboardDatePicker,
@@ -24,6 +29,8 @@ import { Genebank, Individual, inputVariant } from "@app/data_context_global";
 import { useDataContext } from "@app/data_context";
 import { useMessageContext } from "@app/message_context";
 import { IndividualSellingForm } from "./individual_sellingform";
+import { IndividualSell } from "./individual_sell";
+import { IndividualDeath } from "./individual_death";
 import { patch } from "./communication";
 import { isJsxAttribute } from "typescript";
 
@@ -48,11 +55,20 @@ const useStyles = makeStyles({
   formContainer: {
     display: "flex",
     flexDirection: "column",
-    minHeight: "15em",
+    minHeight: "12em",
+    marginBottom: "2em",
     justifyContent: "space-around",
   },
   buttonContainer: {
     display: "flex",
+    marginTop: "1.5em",
+  },
+  altContainer: {
+    display: "flex",
+    flexDirection: "column",
+    padding: "0.5em 0 2em 0",
+    width: "60%",
+    alignItems: "start",
   },
   datePicker: {
     maxWidth: "25em",
@@ -101,7 +117,7 @@ export function IndividualReport({ individual }: { individual: Individual }) {
   const [invalidSale, setInvalidSale] = React.useState(false as boolean);
   const [success, setSuccess] = React.useState(false as boolean);
   const { genebanks } = useDataContext();
-  const { userMessage } = useMessageContext();
+  const { userMessage, popup } = useMessageContext();
   const style = useStyles();
   const disabled: boolean =
     !individualToReport.herd || !individualToReport.selling_date;
@@ -208,9 +224,8 @@ export function IndividualReport({ individual }: { individual: Individual }) {
         <>
           <div className={style.textContainer}>
             <Typography variant="body1" className={style.infoText}>
-              För våran årliga rapport ber vi dig att ge oss aktuell information
-              om kaninens status. OBS! Har du sålt kaninen ber vi dig rapportera
-              detta genom att gå via "Sälj individ".
+              För våran årliga rapport ber vi dig bekräfta att kaninen finns
+              kvar i din besättning.
             </Typography>
           </div>
           <div className={style.formContainer}>
@@ -255,107 +270,31 @@ export function IndividualReport({ individual }: { individual: Individual }) {
               ></FormControlLabel>
             </FormControl>
           </div>
-          <Button
-            color="primary"
-            onClick={() => setShowDeathForm(!showDeathForm)}
-          >
-            Rapportera som död
-            {showDeathForm == false ? <ExpandMore /> : <ExpandLess />}
-          </Button>
-          {showDeathForm ? (
-            <>
-              <FormControl component="fieldset">
-                <FormLabel component="legend">
-                  Har kaninen dött under året?
-                </FormLabel>
-                <RadioGroup
-                  row
-                  aria-label="death"
-                  value={isDead}
-                  onChange={() => setIsDead(!isDead)}
-                >
-                  <FormControlLabel
-                    value={false}
-                    control={<Radio />}
-                    label="Nej"
-                  />
-                  <FormControlLabel
-                    value={true}
-                    control={<Radio />}
-                    label="Ja"
-                  />
-                </RadioGroup>
-              </FormControl>
-              <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                <KeyboardDatePicker
-                  autoOk
-                  disabled={!isDead}
-                  disableFuture
-                  /*                 minDate={new Date(individual.herd_tracking[0].date)}
-                minDateMessage="Datumet måste ligga efter senaste rapporteringsdatumet." */
-                  fullWidth={true}
-                  variant="inline"
-                  inputVariant="outlined"
-                  label="Dödsdatum"
-                  format="yyyy-MM-dd"
-                  value={individualToReport.death_date ?? null}
-                  InputLabelProps={{
-                    shrink: true,
-                  }}
-                  onChange={(event, newValue) => {
-                    newValue && handleUpdateIndividual("death_date", newValue);
-                  }}
-                />
-              </MuiPickersUtilsProvider>
-              <FormControl component="fieldset">
-                <FormLabel component="legend">
-                  Har kaninen slaktats (t.ex. för kött, pga platsbrist e.d.)
-                </FormLabel>
-                <RadioGroup
-                  row
-                  aria-label="butchered"
-                  value={individualToReport.butchered ?? false}
-                  onChange={() =>
-                    handleUpdateIndividual(
-                      "butchered",
-                      !individualToReport.butchered
-                    )
-                  }
-                >
-                  <FormControlLabel
-                    value={false}
-                    control={<Radio disabled={!isDead} />}
-                    label="Nej"
-                  />
-                  <FormControlLabel
-                    value={true}
-                    control={<Radio disabled={!isDead} />}
-                    label="Ja"
-                  />
-                </RadioGroup>
-              </FormControl>
-              <TextField
-                label="Anteckningar om kaninens död"
-                disabled={!isDead}
-                variant={inputVariant}
-                className={style.wideControl}
-                multiline
-                rows={2}
-                value={individualToReport.death_note ?? ""}
-                onChange={(event) => {
-                  handleUpdateIndividual(
-                    "death_note",
-                    event.currentTarget.value
-                  );
-                }}
-              />
-            </>
-          ) : (
-            <></>
-          )}
+          <Typography>
+            Finns kaninen inte kvar i din besättning välj istället en av
+            följande alternativ
+          </Typography>
+          <div className={style.altContainer}>
+            <Button
+              color="primary"
+              size="small"
+              onClick={() => popup(<IndividualDeath individual={individual} />)}
+            >
+              Rapportera som död
+              {<NavigateNext />}
+            </Button>
+            <Button
+              color="primary"
+              size="small"
+              onClick={() => popup(<IndividualSell individual={individual} />)}
+            >
+              Sälj individ
+              {<NavigateNext />}
+            </Button>
+          </div>
           <div className={style.buttonContainer}>
             <Button variant="contained" color="primary" onClick={onSave}>
-              Rapportera
+              Bekräfta
             </Button>
           </div>{" "}
         </>

--- a/frontend/src/individual_report.tsx
+++ b/frontend/src/individual_report.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-
 import {
   Box,
   Button,
@@ -7,32 +6,20 @@ import {
   FormControl,
   FormControlLabel,
   FormHelperText,
-  FormLabel,
   makeStyles,
-  Radio,
-  RadioGroup,
-  TextField,
   Typography,
 } from "@material-ui/core";
-import {
-  CheckCircle,
-  ExpandMore,
-  ExpandLess,
-  NavigateNext,
-} from "@material-ui/icons";
+import { CheckCircle, NavigateNext } from "@material-ui/icons";
 import {
   MuiPickersUtilsProvider,
   KeyboardDatePicker,
 } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
-import { Genebank, Individual, inputVariant } from "@app/data_context_global";
-import { useDataContext } from "@app/data_context";
+import { Individual } from "@app/data_context_global";
 import { useMessageContext } from "@app/message_context";
-import { IndividualSellingForm } from "./individual_sellingform";
 import { IndividualSell } from "./individual_sell";
 import { IndividualDeath } from "./individual_death";
 import { patch } from "./communication";
-import { isJsxAttribute } from "typescript";
 
 const useStyles = makeStyles({
   infoText: {
@@ -88,12 +75,6 @@ const useStyles = makeStyles({
     flexDirection: "row",
     alignItems: "center",
   },
-  wideControl: {
-    margin: "5px 0",
-    minWidth: "195px",
-    width: "100%",
-    paddingRight: "5px",
-  },
 });
 
 interface LimitedIndividual {
@@ -103,105 +84,30 @@ interface LimitedIndividual {
 }
 
 export function IndividualReport({ individual }: { individual: Individual }) {
-  const [genebank, setGenebank] = React.useState(
-    undefined as Genebank | undefined
-  );
-  const [individualToReport, setIndividualToReport] = React.useState(
-    individual as Individual
-  );
-  const [showDeathForm, setShowDeathForm] = React.useState(false);
-  const [isDead, setIsDead] = React.useState(false);
   const [reportDate, setReportDate] = React.useState(null as Date | null);
   const [isStillOwner, setIsStillOwner] = React.useState(false);
-  const [checked, setChecked] = React.useState(false as boolean);
-  const [invalidSale, setInvalidSale] = React.useState(false as boolean);
   const [success, setSuccess] = React.useState(false as boolean);
-  const { genebanks } = useDataContext();
+  const [error, setError] = React.useState(false);
   const { userMessage, popup } = useMessageContext();
   const style = useStyles();
-  const disabled: boolean =
-    !individualToReport.herd || !individualToReport.selling_date;
-  const error: boolean = invalidSale && !checked && !disabled;
-
-  React.useEffect(() => {
-    const currentGenebank = genebanks.find((genebank) =>
-      genebank.individuals.some((i) => i.number == individual.number)
-    );
-
-    setGenebank(currentGenebank);
-  }, [individual]);
-
-  /** Check if individual is dead */
-  React.useEffect(() => {
-    if (!!individual.death_date || !!individual.death_note) {
-      setIsDead(true);
-    }
-  }, [individual]);
-
-  /**
-   * Updates a single field in `individualForSale`.
-   *
-   * @param field field name to update
-   * @param value the new value of the field
-   */
-  const handleUpdateIndividual = <T extends keyof Individual>(
-    field: T,
-    value: Individual[T]
-  ) => {
-    individualToReport &&
-      setIndividualToReport({ ...individualToReport, [field]: value });
-    setInvalidSale(false);
-  };
-
-  /**
-   * make sure "butchered", "death notes" and "death_date" always follow isDead
-   * (an alive rabbit can't be butchered=true and can't have death notes or death_date)
-   */
-  React.useEffect(() => {
-    if (!isDead) {
-      handleUpdateIndividual("butchered", false);
-    }
-  }, [isDead]);
-  React.useEffect(() => {
-    if (!isDead && !individualToReport.butchered) {
-      handleUpdateIndividual("death_note", "");
-    }
-  }, [isDead, individualToReport.butchered]);
-  React.useEffect(() => {
-    if (
-      !isDead &&
-      !individualToReport.butchered &&
-      !individualToReport.death_note
-    ) {
-      handleUpdateIndividual("death_date", null);
-    }
-  }, [isDead, individualToReport.death_note, individualToReport.butchered]);
-
-  const reportAsDead = () => {
-    patch("/api/individual", individualToReport).then((json) => {
-      if (json.status == "success") {
-        setSuccess(true);
-        return;
-      }
-      if (json.status == "error") {
-        userMessage("Något gick fel.", "error");
-      }
-    });
-  };
 
   const onSave = () => {
-    if (isDead) {
-      reportAsDead();
-      return;
-    }
     if (!reportDate) {
       userMessage("Ange ett datum för årsrapporten.", "warning");
       return;
     }
+    if (!isStillOwner) {
+      userMessage(
+        "Bekräfta att kaninen finns kvar i din besättning. Finns den inte kvar, välj ett av de andra alternativ.",
+        "warning"
+      );
+      setError(true);
+      return;
+    }
 
     const limitedIndividual: LimitedIndividual = {
-      number: individualToReport.number,
-      herd: individualToReport.herd,
+      number: individual.number,
+      herd: individual.herd,
       yearly_report_date: reportDate,
     };
     patch("/api/individual", limitedIndividual).then((json) => {
@@ -251,23 +157,30 @@ export function IndividualReport({ individual }: { individual: Individual }) {
               />
             </MuiPickersUtilsProvider>
             <FormControl
-              required
-              error={error}
               component="fieldset"
               disabled={!reportDate}
+              error={error}
               className={style.checkContainer}
             >
               <FormControlLabel
                 control={
                   <Checkbox
                     checked={isStillOwner}
-                    onChange={() => setIsStillOwner(!isStillOwner)}
+                    onChange={() => {
+                      if (error) {
+                        setError(false);
+                      }
+                      setIsStillOwner(!isStillOwner);
+                    }}
                     color="primary"
                     inputProps={{ "aria-label": "primary checkbox" }}
                   />
                 }
                 label="Kaninen finns kvar i min besättning på valt datum."
               ></FormControlLabel>
+              <FormHelperText hidden={!error}>
+                Fältet måste vara ifyllt.
+              </FormHelperText>
             </FormControl>
           </div>
           <Typography>
@@ -309,16 +222,10 @@ export function IndividualReport({ individual }: { individual: Individual }) {
             <h2>Klart!</h2>
             <CheckCircle className={style.successIcon} />
           </div>
-          {isDead ? (
-            <p>
-              {individual.name} {individual.number} har rapporterats som död.
-            </p>
-          ) : (
-            <p>
-              Årsrapporten för {individual.name} {individual.number} har lämnats
-              in.
-            </p>
-          )}
+          <p>
+            Årsrapporten för {individual.name} {individual.number} har lämnats
+            in.
+          </p>
         </Box>
       )}
     </div>

--- a/frontend/src/individual_report.tsx
+++ b/frontend/src/individual_report.tsx
@@ -41,16 +41,21 @@ const useStyles = makeStyles({
   },
   textContainer: {
     padding: "1.5em 0",
-    minHeight: "11em",
     display: "flex",
     flexDirection: "column",
     justifyContent: "space-between",
   },
   formContainer: {
-    maxWidth: "25em",
+    display: "flex",
+    flexDirection: "column",
+    minHeight: "15em",
+    justifyContent: "space-around",
   },
   buttonContainer: {
     display: "flex",
+  },
+  datePicker: {
+    maxWidth: "25em",
   },
   responseBox: {
     width: "100%",
@@ -91,7 +96,7 @@ export function IndividualReport({ individual }: { individual: Individual }) {
   const [showDeathForm, setShowDeathForm] = React.useState(false);
   const [isDead, setIsDead] = React.useState(false);
   const [reportDate, setReportDate] = React.useState(null as Date | null);
-  const [isStillOwner, setIsStillOwner] = React.useState(true);
+  const [isStillOwner, setIsStillOwner] = React.useState(false);
   const [checked, setChecked] = React.useState(false as boolean);
   const [invalidSale, setInvalidSale] = React.useState(false as boolean);
   const [success, setSuccess] = React.useState(false as boolean);
@@ -204,28 +209,22 @@ export function IndividualReport({ individual }: { individual: Individual }) {
           <div className={style.textContainer}>
             <Typography variant="body1" className={style.infoText}>
               För våran årliga rapport ber vi dig att ge oss aktuell information
-              om kaninens status.
-            </Typography>
-            <Typography variant="body1" className={style.infoText}>
-              OBS! Har du sålt kaninen ber vi dig rapportera detta genom att gå
-              via "Sälj individ".
+              om kaninens status. OBS! Har du sålt kaninen ber vi dig rapportera
+              detta genom att gå via "Sälj individ".
             </Typography>
           </div>
           <div className={style.formContainer}>
-            <p>
-              Välj ett datum för din årliga rapport. Nedanstående uppgifterna
-              registreras för det här datumet.
-            </p>
             <MuiPickersUtilsProvider utils={DateFnsUtils}>
               <KeyboardDatePicker
                 autoOk
+                className={style.datePicker}
                 disableFuture
                 /*                 minDate={new Date(individual.herd_tracking[0].date)}
                 minDateMessage="Datumet måste ligga efter senaste rapporteringsdatumet." */
-                fullWidth={true}
                 variant="inline"
                 inputVariant="outlined"
                 label="Rapportdatum"
+                helperText="Rapporten registreras på valt datum."
                 format="yyyy-MM-dd"
                 value={reportDate ?? null}
                 InputLabelProps={{
@@ -236,23 +235,24 @@ export function IndividualReport({ individual }: { individual: Individual }) {
                 }}
               />
             </MuiPickersUtilsProvider>
-            <FormControl component="fieldset">
-              <FormLabel component="legend">
-                Kaninen finns fortfarande i min besättning.
-              </FormLabel>
-              <RadioGroup
-                row
-                aria-label="still active"
-                value={isStillOwner}
-                onChange={() => setIsStillOwner(!isStillOwner)}
-              >
-                <FormControlLabel
-                  value={false}
-                  control={<Radio />}
-                  label="Nej"
-                />
-                <FormControlLabel value={true} control={<Radio />} label="Ja" />
-              </RadioGroup>
+            <FormControl
+              required
+              error={error}
+              component="fieldset"
+              disabled={!reportDate}
+              className={style.checkContainer}
+            >
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={isStillOwner}
+                    onChange={() => setIsStillOwner(!isStillOwner)}
+                    color="primary"
+                    inputProps={{ "aria-label": "primary checkbox" }}
+                  />
+                }
+                label="Kaninen finns kvar i min besättning på valt datum."
+              ></FormControlLabel>
             </FormControl>
           </div>
           <Button

--- a/frontend/src/individual_report.tsx
+++ b/frontend/src/individual_report.tsx
@@ -166,10 +166,6 @@ export function IndividualReport({ individual }: { individual: Individual }) {
     }
   }, [isDead, individualToReport.death_note, individualToReport.butchered]);
 
-  const handleCheckbox = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setChecked(event.target.checked);
-  };
-
   const sellIndividual = () => {
     if (!checked) {
       setInvalidSale(true);
@@ -223,6 +219,7 @@ export function IndividualReport({ individual }: { individual: Individual }) {
             <MuiPickersUtilsProvider utils={DateFnsUtils}>
               <KeyboardDatePicker
                 autoOk
+                disableFuture
                 fullWidth={true}
                 variant="inline"
                 inputVariant="outlined"
@@ -356,31 +353,6 @@ export function IndividualReport({ individual }: { individual: Individual }) {
           ) : (
             <></>
           )}
-          <div>
-            <FormControl
-              required
-              error={error}
-              component="fieldset"
-              disabled={disabled}
-              className={style.checkContainer}
-            >
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={checked}
-                    onChange={handleCheckbox}
-                    color="primary"
-                    inputProps={{ "aria-label": "primary checkbox" }}
-                  />
-                }
-                label="Jag har tagit del av informationen och vill ta bort individen
-            från min besättning."
-              ></FormControlLabel>
-              <FormHelperText hidden={!error}>
-                Bekräfta att du tagit del av informationen.
-              </FormHelperText>
-            </FormControl>
-          </div>
           <div className={style.buttonContainer}>
             <Button
               variant="contained"

--- a/frontend/src/individual_report.tsx
+++ b/frontend/src/individual_report.tsx
@@ -91,6 +91,13 @@ export function IndividualReport({ individual }: { individual: Individual }) {
   const { userMessage, popup } = useMessageContext();
   const style = useStyles();
 
+  const getMinDate = () => {
+    const lastTracking = new Date(individual.herd_tracking[0].date);
+    const earliest = new Date(lastTracking.getTime() + 1000 * 60 * 60 * 24);
+    return earliest;
+  };
+  const minDate: Date = getMinDate();
+
   const onSave = () => {
     if (!reportDate) {
       userMessage("Ange ett datum för årsrapporten.", "warning");
@@ -130,8 +137,8 @@ export function IndividualReport({ individual }: { individual: Individual }) {
         <>
           <div className={style.textContainer}>
             <Typography variant="body1" className={style.infoText}>
-              För våran årliga rapport ber vi dig bekräfta att kaninen finns
-              kvar i din besättning.
+              För våran årliga rapport ber vi dig bekräfta att kaninen finns i
+              din besättning. <br></br> Utgår från datumet du väljer nedan.
             </Typography>
           </div>
           <div className={style.formContainer}>
@@ -140,12 +147,11 @@ export function IndividualReport({ individual }: { individual: Individual }) {
                 autoOk
                 className={style.datePicker}
                 disableFuture
-                /*                 minDate={new Date(individual.herd_tracking[0].date)}
-                minDateMessage="Datumet måste ligga efter senaste rapporteringsdatumet." */
+                minDate={minDate}
+                minDateMessage="Datumet måste ligga efter senaste rapporteringsdatum."
                 variant="inline"
                 inputVariant="outlined"
-                label="Rapportdatum"
-                helperText="Rapporten registreras på valt datum."
+                label="Datum för årsrapporten"
                 format="yyyy-MM-dd"
                 value={reportDate ?? null}
                 InputLabelProps={{
@@ -184,7 +190,7 @@ export function IndividualReport({ individual }: { individual: Individual }) {
             </FormControl>
           </div>
           <Typography>
-            Finns kaninen inte kvar i din besättning välj istället en av
+            Finns kaninen inte kvar i din besättning välj istället ett av
             följande alternativ
           </Typography>
           <div className={style.altContainer}>
@@ -207,7 +213,7 @@ export function IndividualReport({ individual }: { individual: Individual }) {
           </div>
           <div className={style.buttonContainer}>
             <Button variant="contained" color="primary" onClick={onSave}>
-              Bekräfta
+              Skicka
             </Button>
           </div>{" "}
         </>

--- a/frontend/src/individual_report.tsx
+++ b/frontend/src/individual_report.tsx
@@ -1,0 +1,266 @@
+import React from "react";
+
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  makeStyles,
+  Radio,
+  RadioGroup,
+  Typography,
+} from "@material-ui/core";
+import { CheckCircle } from "@material-ui/icons";
+
+import { Genebank, Individual } from "@app/data_context_global";
+import { useDataContext } from "@app/data_context";
+import { useMessageContext } from "@app/message_context";
+import { IndividualSellingForm } from "./individual_sellingform";
+import { patch } from "./communication";
+
+const useStyles = makeStyles({
+  infoText: {
+    maxWidth: "40em",
+  },
+  checkContainer: {
+    margin: "1.5em 0",
+  },
+  popupContainer: {
+    maxWidth: "45em",
+    display: "flex",
+    flexDirection: "column",
+  },
+  textContainer: {
+    padding: "1.5em 0",
+    minHeight: "11em",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "space-between",
+  },
+  formContainer: {
+    maxWidth: "25em",
+  },
+  buttonContainer: {
+    display: "flex",
+  },
+  responseBox: {
+    width: "100%",
+    maxWidth: "65em",
+    padding: "1em",
+    margin: "2em 0",
+  },
+  successIcon: {
+    fill: "#388e3c", // same as success.dark in the default theme
+    marginLeft: "0.5em",
+  },
+  boxTitle: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+  },
+});
+
+interface LimitedIndividualForSale {
+  number: string;
+  herd: string;
+  selling_date: string;
+}
+
+export function IndividualReport({ individual }: { individual: Individual }) {
+  const [genebank, setGenebank] = React.useState(
+    undefined as Genebank | undefined
+  );
+  const [individualToReport, setIndividualToReport] = React.useState(
+    individual as Individual
+  );
+  const [isDead, setIsDead] = React.useState(false);
+  const [checked, setChecked] = React.useState(false as boolean);
+  const [invalidSale, setInvalidSale] = React.useState(false as boolean);
+  const [success, setSuccess] = React.useState(false as boolean);
+  const { genebanks } = useDataContext();
+  const { userMessage } = useMessageContext();
+  const style = useStyles();
+  const disabled: boolean =
+    !individualToReport.herd || !individualToReport.selling_date;
+  const error: boolean = invalidSale && !checked && !disabled;
+
+  React.useEffect(() => {
+    const currentGenebank = genebanks.find((genebank) =>
+      genebank.individuals.some((i) => i.number == individual.number)
+    );
+
+    setGenebank(currentGenebank);
+  }, [individual]);
+
+  /** Check if individual is dead */
+  React.useEffect(() => {
+    if (!!individual.death_date || !!individual.death_note) {
+      setIsDead(true);
+    }
+  }, [individual]);
+
+  /**
+   * Updates a single field in `individualForSale`.
+   *
+   * @param field field name to update
+   * @param value the new value of the field
+   */
+  const handleUpdateIndividual = <T extends keyof Individual>(
+    field: T,
+    value: Individual[T]
+  ) => {
+    individualToReport &&
+      setIndividualToReport({ ...individualToReport, [field]: value });
+    setInvalidSale(false);
+  };
+
+  /*
+  delete the herd field from individualForSale to get the dropdown input for 
+  herd empty when component is rendered
+  */
+  React.useEffect(() => {
+    let currentIndividual = individualToReport;
+    delete currentIndividual.herd;
+    setIndividualToReport(currentIndividual);
+  }, []);
+
+  const handleCheckbox = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(event.target.checked);
+  };
+
+  const sellIndividual = () => {
+    if (!checked) {
+      setInvalidSale(true);
+      return;
+    }
+    if (!individualToReport.herd) {
+      userMessage("Fyll i en besättning först", "warning");
+      return;
+    }
+    if (!individualToReport.selling_date) {
+      userMessage("Fyll i ett köpdatum först.", "warning");
+      return;
+    }
+    const limitedIndividual: LimitedIndividualForSale = {
+      number: individualToReport.number,
+      herd: individualToReport.herd,
+      selling_date: individualToReport.selling_date,
+    };
+    patch("/api/individual", limitedIndividual).then((json) => {
+      if (json.status == "success") {
+        setSuccess(true);
+        return;
+      }
+      if (json.status == "error") {
+      }
+    });
+  };
+
+  return (
+    <div className={style.popupContainer}>
+      <h2>
+        Årsrappportera {individual.name} {individual.number}
+      </h2>
+      {!success ? (
+        <>
+          <div className={style.textContainer}>
+            <Typography variant="body1" className={style.infoText}>
+              För våran årliga rapport ber vi dig att ge oss aktuell information
+              om kaninens status.
+            </Typography>
+          </div>
+          <div className={style.formContainer}>
+            <FormControl component="fieldset">
+              <FormLabel component="legend">
+                Har kaninen dött under året?
+              </FormLabel>
+              <RadioGroup
+                row
+                aria-label="death"
+                value={isDead}
+                onChange={() => setIsDead(!isDead)}
+              >
+                <FormControlLabel
+                  value={false}
+                  control={<Radio />}
+                  label="Nej"
+                />
+                <FormControlLabel value={true} control={<Radio />} label="Ja" />
+              </RadioGroup>
+            </FormControl>
+            <FormControl component="fieldset">
+              <FormLabel component="legend">
+                Har kaninen slaktats (t.ex. för kött, pga platsbrist e.d.)
+              </FormLabel>
+              <RadioGroup
+                row
+                aria-label="butchered"
+                value={false}
+                onChange={() => {}}
+              >
+                <FormControlLabel
+                  value={false}
+                  control={<Radio />}
+                  label="Nej"
+                />
+                <FormControlLabel value={true} control={<Radio />} label="Ja" />
+              </RadioGroup>
+            </FormControl>
+          </div>
+          <div>
+            <FormControl
+              required
+              error={error}
+              component="fieldset"
+              disabled={disabled}
+              className={style.checkContainer}
+            >
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={checked}
+                    onChange={handleCheckbox}
+                    color="primary"
+                    inputProps={{ "aria-label": "primary checkbox" }}
+                  />
+                }
+                label="Jag har tagit del av informationen och vill ta bort individen
+            från min besättning."
+              ></FormControlLabel>
+              <FormHelperText hidden={!error}>
+                Bekräfta att du tagit del av informationen.
+              </FormHelperText>
+            </FormControl>
+          </div>
+          <div className={style.buttonContainer}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={sellIndividual}
+            >
+              Sälj
+            </Button>
+          </div>{" "}
+        </>
+      ) : (
+        <Box
+          border={3}
+          borderRadius={8}
+          borderColor="success.light"
+          className={style.responseBox}
+        >
+          <div className={style.boxTitle}>
+            <h2>Klart!</h2>
+            <CheckCircle className={style.successIcon} />
+          </div>
+          <p>
+            Individen har flyttats till besättning {individualToReport.herd}.
+          </p>
+        </Box>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/individual_view.tsx
+++ b/frontend/src/individual_view.tsx
@@ -31,6 +31,7 @@ import { CertificateVerification } from "./certificate_verification";
 import { CertificateDownload } from "./certificate_download";
 import { IndividualSell } from "./individual_sell";
 import { HerdView } from "@app/herd_view";
+import { IndividualReport } from "./individual_report";
 
 const useStyles = makeStyles({
   body: {
@@ -389,16 +390,28 @@ export function IndividualView({ id }: { id: string }) {
                     })}
                 </ul>
                 {user?.canEdit(individual.herd.herd) && (
-                  <Button
-                    className={style.editButton}
-                    variant="outlined"
-                    color="primary"
-                    onClick={() =>
-                      popup(<IndividualSell individual={individual} />)
-                    }
-                  >
-                    Sälj individ
-                  </Button>
+                  <>
+                    <Button
+                      className={style.editButton}
+                      variant="outlined"
+                      color="primary"
+                      onClick={() =>
+                        popup(<IndividualSell individual={individual} />)
+                      }
+                    >
+                      Sälj individ
+                    </Button>
+                    <Button
+                      className={style.editButton}
+                      variant="outlined"
+                      color="primary"
+                      onClick={() =>
+                        popup(<IndividualReport individual={individual} />)
+                      }
+                    >
+                      Årsrapportera
+                    </Button>
+                  </>
                 )}
               </div>
               <div>

--- a/frontend/src/individual_view.tsx
+++ b/frontend/src/individual_view.tsx
@@ -32,6 +32,7 @@ import { CertificateDownload } from "./certificate_download";
 import { IndividualSell } from "./individual_sell";
 import { HerdView } from "@app/herd_view";
 import { IndividualReport } from "./individual_report";
+import { IndividualDeath } from "./individual_death";
 
 const useStyles = makeStyles({
   body: {
@@ -410,6 +411,16 @@ export function IndividualView({ id }: { id: string }) {
                       }
                     >
                       Årsrapportera
+                    </Button>
+                    <Button
+                      className={style.editButton}
+                      variant="outlined"
+                      color="primary"
+                      onClick={() =>
+                        popup(<IndividualDeath individual={individual} />)
+                      }
+                    >
+                      Rapportera som död
                     </Button>
                   </>
                 )}

--- a/frontend/src/individual_view.tsx
+++ b/frontend/src/individual_view.tsx
@@ -392,36 +392,40 @@ export function IndividualView({ id }: { id: string }) {
                 </ul>
                 {user?.canEdit(individual.herd.herd) && (
                   <>
-                    <Button
-                      className={style.editButton}
-                      variant="outlined"
-                      color="primary"
-                      onClick={() =>
-                        popup(<IndividualSell individual={individual} />)
-                      }
-                    >
-                      Sälj individ
-                    </Button>
-                    <Button
-                      className={style.editButton}
-                      variant="outlined"
-                      color="primary"
-                      onClick={() =>
-                        popup(<IndividualReport individual={individual} />)
-                      }
-                    >
-                      Årsrapportera
-                    </Button>
-                    <Button
-                      className={style.editButton}
-                      variant="outlined"
-                      color="primary"
-                      onClick={() =>
-                        popup(<IndividualDeath individual={individual} />)
-                      }
-                    >
-                      Rapportera som död
-                    </Button>
+                    {!individual.death_date && !individual.death_note && (
+                      <>
+                        <Button
+                          className={style.editButton}
+                          variant="outlined"
+                          color="primary"
+                          onClick={() =>
+                            popup(<IndividualSell individual={individual} />)
+                          }
+                        >
+                          Sälj individ
+                        </Button>
+                        <Button
+                          className={style.editButton}
+                          variant="outlined"
+                          color="primary"
+                          onClick={() =>
+                            popup(<IndividualReport individual={individual} />)
+                          }
+                        >
+                          Årsrapportera
+                        </Button>
+                        <Button
+                          className={style.editButton}
+                          variant="outlined"
+                          color="primary"
+                          onClick={() =>
+                            popup(<IndividualDeath individual={individual} />)
+                          }
+                        >
+                          Rapportera som död
+                        </Button>
+                      </>
+                    )}
                   </>
                 )}
               </div>

--- a/frontend/src/individual_view.tsx
+++ b/frontend/src/individual_view.tsx
@@ -393,7 +393,7 @@ export function IndividualView({ id }: { id: string }) {
                 {user?.canEdit(individual.herd.herd) && (
                   <>
                     {!individual.death_date && !individual.death_note && (
-                      <>
+                      <div className={style.flexColumn}>
                         <Button
                           className={style.editButton}
                           variant="outlined"
@@ -424,7 +424,7 @@ export function IndividualView({ id }: { id: string }) {
                         >
                           Rapportera som död
                         </Button>
-                      </>
+                      </div>
                     )}
                   </>
                 )}


### PR DESCRIPTION
Users can now send in a (very basic) yearly report where they confirm that a rabbit is still active in their herd. (To prevent the rabbit from becoming inactive 365 after the latest herdtracking).
They can also mark a rabbit as dead. 
fixes #139 