### PR TITLE
Add herd start date

### DIFF
--- a/scripts/load-gotland.sh
+++ b/scripts/load-gotland.sh
@@ -417,8 +417,14 @@ psql --quiet <<-'END_SQL'
 	ALTER TABLE g_data2 ALTER "Nr" TYPE NUMERIC USING "Nr"::numeric;
 	ALTER TABLE g_data2 ALTER "Nr" TYPE INTEGER USING "Nr"::integer;
 	ALTER TABLE g_data2 ALTER "Nr" TYPE VARCHAR(10);
+
 	UPDATE g_data2 SET "Nr" = CONCAT('G', "Nr")
 	WHERE "Nr" IS NOT NULL AND "Nr" NOT LIKE 'G%';
+
+	UPDATE	g_data2 SET "Start" = NULL
+	WHERE	"Start" NOT LIKE '____-__-__';
+
+	ALTER TABLE g_data2 ALTER "Start" TYPE DATE USING "Start"::date;
 
 	-- Add herd names
 	UPDATE herd h
@@ -448,6 +454,18 @@ psql --quiet <<-'END_SQL'
 	UPDATE herd h
 	SET name = (
 		SELECT "Namn"
+		FROM	g_data2
+		WHERE	"Nr" = h.herd
+		LIMIT	1
+	)
+	FROM	genebank gb
+	WHERE	gb.genebank_id = h.genebank_id
+	AND	gb.name = 'Gotlandskanin';
+
+	-- Add start date
+	UPDATE herd h
+	SET start_date = (
+		SELECT	"Start"
 		FROM	g_data2
 		WHERE	"Nr" = h.herd
 		LIMIT	1

--- a/scripts/load-mellerud.sh
+++ b/scripts/load-mellerud.sh
@@ -284,8 +284,15 @@ psql --echo-errors --quiet <<-'END_SQL'
 	ALTER TABLE m_data2 ALTER "Genbanknr." TYPE NUMERIC USING "Genbanknr."::numeric;
 	ALTER TABLE m_data2 ALTER "Genbanknr." TYPE INTEGER USING "Genbanknr."::integer;
 	ALTER TABLE m_data2 ALTER "Genbanknr." TYPE VARCHAR(9);
+
 	UPDATE m_data2 SET "Genbanknr." = CONCAT('M', "Genbanknr.")
 	       WHERE "Genbanknr." IS NOT NULL AND "Genbanknr." NOT LIKE 'M%';
+
+	UPDATE	m_data2
+	SET	"Start" = CONCAT("Start", '-01-01')
+	WHERE	"Start" LIKE ('____');
+
+	ALTER TABLE m_data2 ALTER "Start" TYPE DATE USING "Start"::date;
 
 	UPDATE herd h
 	SET herd_name = (
@@ -322,4 +329,16 @@ psql --echo-errors --quiet <<-'END_SQL'
 	WHERE	gb.genebank_id = h.genebank_id
 	AND	gb.name = 'Mellerudskanin'
 	AND	h.is_active IS NULL;
+
+	UPDATE	herd h
+	SET	start_date = (
+		SELECT "Start"
+		FROM	m_data2
+		WHERE	"Genbanknr." = h.herd
+		LIMIT	1
+	)
+	FROM	genebank gb
+	WHERE	gb.genebank_id = h.genebank_id
+	AND	gb.name = 'Mellerudskanin'
+	AND	h.start_date IS NULL;
 END_SQL


### PR DESCRIPTION
Read the herd "start date" from the auxiliary data file and insert it
into the `herd` table.  This requires us to first remove any data that
is not on the `YYYY-MM-DD` form, and then change the column format on
the `g_data2` table for the `"Start"` column, before simply doing an
`UPDATE` as for the other pieces of auxiliary data.

Resolves #417 