### PR TITLE
Herd view table updates automatically

### DIFF
--- a/app/tests/test_data_access.py
+++ b/app/tests/test_data_access.py
@@ -176,7 +176,7 @@ class TestDataAccess(DatabaseTest):
                 if target["genebank"] not in user.accessible_genebanks:
                     target = None
                 else:
-                    target["individuals"] = [i.short_info() for i in herd.individuals]
+                    target["individuals"] = [i.as_dict() for i in herd.individuals]
 
                 if value is None or target is None:
                     self.assertEqual(value, target)

--- a/app/tests/test_database.py
+++ b/app/tests/test_database.py
@@ -308,6 +308,10 @@ class TestDatabase(DatabaseTest):
         data["mother"] = mother
         data["father"] = father
         data["color"] = self.colors[0].name
+        data["alive"] = (
+            not self.individuals[0].death_date and not self.individuals[0].death_note
+        )
+        data["is_active"] = None
         data["weights"] = [
             {
                 "weight": self.weights[0].weight,
@@ -350,7 +354,8 @@ class TestDatabase(DatabaseTest):
             }
 
             is_active = (
-                individual.is_active
+                individual.current_herd.is_active
+                and not individual.castration_date
                 and not individual.death_date
                 and not individual.death_note
                 and (

--- a/app/tests/test_permissions.py
+++ b/app/tests/test_permissions.py
@@ -104,7 +104,7 @@ class TestPermissions(DatabaseTest):
                 if expected["genebank"] not in user.accessible_genebanks:
                     self.assertIsNone(value)
                 else:
-                    expected["individuals"] = [i.short_info() for i in herd.individuals]
+                    expected["individuals"] = [i.as_dict() for i in herd.individuals]
                     self.assertDictEqual(expected, value)
 
     def test_add_herd(self):

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -640,7 +640,7 @@ def get_herd(herd_id, user_uuid=None):
             if data["genebank"] not in user.accessible_genebanks:
                 return None
 
-            data["individuals"] = [i.short_info() for i in herd.individuals]
+            data["individuals"] = [i.as_dict() for i in herd.individuals]
             return data
     except DoesNotExist:
         return data

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -825,7 +825,7 @@ def form_to_individual(form, user=None):
     # object.
     for key in vars(Individual).keys():
         if form.get(key, None) is not None:
-            if key.startswith("_") or key is "alive":
+            if key.startswith("_") or key == "alive":
                 continue
             if key and key.endswith("date"):
                 try:

--- a/app/utils/data_access.py
+++ b/app/utils/data_access.py
@@ -825,7 +825,7 @@ def form_to_individual(form, user=None):
     # object.
     for key in vars(Individual).keys():
         if form.get(key, None) is not None:
-            if key.startswith("_"):
+            if key.startswith("_") or key is "alive":
                 continue
             if key and key.endswith("date"):
                 try:

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -521,9 +521,10 @@ class Individual(BaseModel):
         Returns if an individual fullfils the requirements to be active.
         """
         is_active = (
-            self.is_active
-            and not self.death_date
+            not self.death_date
             and not self.death_note
+            and not self.castration_date
+            and not self.current_herd.herd in ["GX1", "MX1"]
             and self.latest_herdtracking_entry
             and (
                 self.latest_herdtracking_entry.herd_tracking_date
@@ -531,6 +532,14 @@ class Individual(BaseModel):
             )
         )
         return is_active
+
+    @property
+    def alive(self):
+        """
+        Returns if an indivdual is alive
+        """
+        is_alive = not self.death_date and not self.death_note
+        return is_alive
 
     def as_dict(self):
         """
@@ -551,7 +560,7 @@ class Individual(BaseModel):
             "herd": self.current_herd.herd,
             "herd_name": self.current_herd.herd_name,
         }
-
+        data["alive"] = self.alive
         data["birth_date"] = self.breeding.birth_date if self.breeding else None
         data["litter"] = self.breeding.litter_size if self.breeding else None
 

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -521,10 +521,10 @@ class Individual(BaseModel):
         Returns if an individual fullfils the requirements to be active.
         """
         is_active = (
-            not self.death_date
+            self.current_herd.is_active
+            and not self.death_date
             and not self.death_note
             and not self.castration_date
-            and not self.current_herd.herd in ["GX1", "MX1"]
             and self.latest_herdtracking_entry
             and (
                 self.latest_herdtracking_entry.herd_tracking_date

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -57,7 +57,8 @@ export function BreedingForm({
   handleBreedingsChanged: () => void;
   handleActive: (breeding: Breeding) => void;
 }) {
-  const { genebanks } = useDataContext();
+  const { genebanks, herdListener, herdChangeListener, setHerdChangeListener } =
+    useDataContext();
   const {
     createBreeding,
     createBirth,
@@ -201,6 +202,9 @@ export function BreedingForm({
       (json) => {
         switch (json.status) {
           case "success": {
+            if (herdListener == individual.herd) {
+              setHerdChangeListener(herdChangeListener + 1);
+            }
             userMessage("Kaninen har lagts till i din besättning.", "success");
             break;
           }

--- a/frontend/src/data_context.tsx
+++ b/frontend/src/data_context.tsx
@@ -30,6 +30,8 @@ export function useDataContext(): DataContext {
 
 export function WithDataContext(props: { children: React.ReactNode }) {
   const [genebanks, setGenebanks] = React.useState([] as Array<Genebank>);
+  const [herdListener, setHerdListener] = React.useState("");
+  const [herdChangeListener, setHerdChangeListener] = React.useState(0);
   const [users, setUsers] = React.useState([] as Array<NameID>);
   const [colors, setColors] = React.useState(
     {} as { [genebank: string]: Color[] }
@@ -195,6 +197,10 @@ export function WithDataContext(props: { children: React.ReactNode }) {
         genebanks,
         users,
         colors,
+        herdChangeListener,
+        herdListener,
+        setHerdChangeListener,
+        setHerdListener,
         setGenebanks,
         setUsers,
         loadData,

--- a/frontend/src/data_context.tsx
+++ b/frontend/src/data_context.tsx
@@ -30,6 +30,12 @@ export function useDataContext(): DataContext {
 
 export function WithDataContext(props: { children: React.ReactNode }) {
   const [genebanks, setGenebanks] = React.useState([] as Array<Genebank>);
+  /**
+   * The herd listener will save a herd id as soon as the user opens a herd view.
+   * The herd change listener will increase every time an individual of that herd is updated, sold or added.
+   * Herd view will fetch the herd's data every time the listener changes.
+   * This way, changes will be visible in herd view immediately, no page reload needed.
+   */
   const [herdListener, setHerdListener] = React.useState("");
   const [herdChangeListener, setHerdChangeListener] = React.useState(0);
   const [users, setUsers] = React.useState([] as Array<NameID>);

--- a/frontend/src/data_context_global.tsx
+++ b/frontend/src/data_context_global.tsx
@@ -176,6 +176,10 @@ export interface DataContext {
   genebanks: Array<Genebank>;
   users: Array<NameID>;
   colors: { [genebank: string]: Color[] };
+  herdChangeListener: number;
+  herdListener: string;
+  setHerdChangeListener(data: number): void;
+  setHerdListener(data: string): void;
   setGenebanks(data: Genebank[]): void;
   setUsers(data: NameID[]): void;
   loadData(data: string | Array<string>): Promise<boolean>;

--- a/frontend/src/filter_table.tsx
+++ b/frontend/src/filter_table.tsx
@@ -217,16 +217,26 @@ export function FilterTable({
           `/herd/${rowData.herd["herd"]}`,
           true
         ),
+      /**
+       * render makes two exceptions for GX1 and MX1 due to inefficient herd fetching when opening HerdView.
+       * Because GX1 and MX1 are unusually large, trying to open HerdView for them will crash the page.
+       * As it's not needed from a user perspective, these exceptions disable the link for opening HerdView.
+       * Consider it a workaround until herd fetching is more efficient.
+       */
       render: (rowData: any) => (
         <a
-          className="functionLink"
-          onClick={() =>
-            popup(
-              <HerdView id={rowData.herd["herd"]} />,
-              `/herd/${rowData.herd["herd"]}`,
-              true
-            )
+          className={
+            rowData.herd.herd !== ("GX1" || "MX1") ? "functionLink" : ""
           }
+          onClick={() => {
+            if (rowData.herd.herd !== ("GX1" || "MX1")) {
+              popup(
+                <HerdView id={rowData.herd["herd"]} />,
+                `/herd/${rowData.herd["herd"]}`,
+                true
+              );
+            }
+          }}
         >
           {rowData.herd["herd"]}
         </a>

--- a/frontend/src/filter_table.tsx
+++ b/frontend/src/filter_table.tsx
@@ -235,6 +235,11 @@ export function FilterTable({
     { field: "name", label: "Namn" },
     { field: "certificate", label: "Certifikat", hidden: true },
     {
+      field: "digital_certificate",
+      label: "Digitalt certifikat",
+      hidden: true,
+    },
+    {
       field: "number",
       label: "Nummer",
       sortAs: "numbers",

--- a/frontend/src/filter_table.tsx
+++ b/frontend/src/filter_table.tsx
@@ -310,7 +310,15 @@ export function FilterTable({
       field: "color",
       label: "Färg",
       sortBy: "name",
-      render: (rowData: any) => rowData.color["name"],
+      render: (rowData: any) => {
+        if (typeof rowData.color == "string") {
+          return rowData.color;
+        } else if (rowData.color && !!rowData.color["name"]) {
+          return rowData.color["name"];
+        } else {
+          return undefined;
+        }
+      },
     },
     { field: "color_note", label: "Färganteckning", hidden: true },
   ];

--- a/frontend/src/herd_view.tsx
+++ b/frontend/src/herd_view.tsx
@@ -94,19 +94,10 @@ export function HerdView({ id }: { id: string | undefined }) {
   }, [id]);
 
   React.useEffect(() => {
-    if (herd && genebanks && herd.individuals) {
-      const genebank = genebanks.find((g) =>
-        g.herds.some((h) => h.herd == herd.herd)
-      );
-      const individualIds = herd.individuals.map((i) => i.number);
-      if (genebank && genebank.individuals != null) {
-        const individualsList = genebank.individuals.filter((i) =>
-          individualIds.includes(i.number)
-        );
-        setHerdIndividuals(individualsList);
-      }
+    if (herd && herd.individuals) {
+      setHerdIndividuals(herd.individuals);
     }
-  }, [herd, genebanks]);
+  }, [herd]);
 
   return (
     <>

--- a/frontend/src/herd_view.tsx
+++ b/frontend/src/herd_view.tsx
@@ -65,7 +65,13 @@ export function HerdView({ id }: { id: string | undefined }) {
   const [activeTab, setActiveTab] = React.useState("list" as TabValue);
   const { userMessage, popup } = useMessageContext();
   const { user } = useUserContext();
-  const { genebanks } = useDataContext();
+  const {
+    genebanks,
+    herdChangeListener,
+    herdListener,
+    setHerdChangeListener,
+    setHerdListener,
+  } = useDataContext();
   const [algo, set_algo] = React.useState("Martin" as "Martin" | "Dan");
   const [pedigreeView, setPedigreeView] = React.useState(false as boolean);
 
@@ -79,6 +85,7 @@ export function HerdView({ id }: { id: string | undefined }) {
 
   const getHerd = () => {
     if (id) {
+      setHerdListener(id);
       get(`/api/herd/${id}`).then(
         (data: Herd) => data && setHerd(data),
         (error) => {
@@ -91,7 +98,7 @@ export function HerdView({ id }: { id: string | undefined }) {
 
   React.useEffect(() => {
     getHerd();
-  }, [id]);
+  }, [id, herdChangeListener]);
 
   React.useEffect(() => {
     if (herd && herd.individuals) {

--- a/frontend/src/herd_view.tsx
+++ b/frontend/src/herd_view.tsx
@@ -77,7 +77,7 @@ export function HerdView({ id }: { id: string | undefined }) {
     [genebanks, id, algo, pedigreeView]
   );
 
-  React.useEffect(() => {
+  const getHerd = () => {
     if (id) {
       get(`/api/herd/${id}`).then(
         (data: Herd) => data && setHerd(data),
@@ -87,6 +87,10 @@ export function HerdView({ id }: { id: string | undefined }) {
         }
       );
     }
+  };
+
+  React.useEffect(() => {
+    getHerd();
   }, [id]);
 
   React.useEffect(() => {
@@ -119,7 +123,13 @@ export function HerdView({ id }: { id: string | undefined }) {
             textColor="primary"
             variant="fullWidth"
           >
-            <Tab label="Lista över individer" value="list" />
+            <Tab
+              label="Lista över individer"
+              value="list"
+              onClick={() => {
+                getHerd();
+              }}
+            />
             <Tab label="Parningstillfällen" value="breeding" />
             <Tab
               label="Släktträd för besättningen"

--- a/frontend/src/individual_add.tsx
+++ b/frontend/src/individual_add.tsx
@@ -145,7 +145,8 @@ export function IndividualAdd({
   const { userMessage, popup } = useMessageContext();
   const { user } = useUserContext();
   const is_admin = !!(user?.is_manager || user?.is_admin);
-  const { genebanks } = useDataContext();
+  const { genebanks, herdListener, herdChangeListener, setHerdChangeListener } =
+    useDataContext();
   const {
     createBreeding,
     createBirth,
@@ -391,6 +392,9 @@ export function IndividualAdd({
                 "Kaninen har lagts till i din besättning.",
                 "success"
               );
+              if (herdListener == individual.herd) {
+                setHerdChangeListener(herdChangeListener + 1);
+              }
             } else setSuccess(true);
             break;
           }

--- a/frontend/src/individual_certificate.tsx
+++ b/frontend/src/individual_certificate.tsx
@@ -97,6 +97,8 @@ export function IndividualCertificate({
   const { user } = useUserContext();
   const { popup } = useMessageContext();
   const { userMessage } = useMessageContext();
+  const { herdListener, herdChangeListener, setHerdChangeListener } =
+    useDataContext();
   const style = useStyles();
 
   // Limited version of the individual to be used for the preview
@@ -282,6 +284,9 @@ export function IndividualCertificate({
           setCertificateUrl(window.URL.createObjectURL(blob));
           setShowSummary(false);
           setShowComplete(true);
+          if (herdListener == individual?.herd.herd) {
+            setHerdChangeListener(herdChangeListener + 1);
+          }
         } else {
           throw new Error("Något gick fel (det här borde inte hända).");
         }
@@ -321,6 +326,9 @@ export function IndividualCertificate({
           setCertificateUrl(window.URL.createObjectURL(blob));
           setShowSummary(false);
           setShowComplete(true);
+          if (herdListener == individual?.herd.herd) {
+            setHerdChangeListener(herdChangeListener + 1);
+          }
         } else {
           throw new Error("Något gick fel.");
         }

--- a/frontend/src/individual_death.tsx
+++ b/frontend/src/individual_death.tsx
@@ -127,7 +127,7 @@ export const IndividualDeath = ({ individual }: { individual: Individual }) => {
     patch("/api/individual", deadIndividual).then((json) => {
       if (json.status == "success") {
         setSuccess(true);
-        if (deadIndividual.herd == herdListener) {
+        if (deadIndividual.herd.herd == herdListener) {
           setHerdChangeListener(herdChangeListener + 1);
         }
         return;

--- a/frontend/src/individual_death.tsx
+++ b/frontend/src/individual_death.tsx
@@ -20,6 +20,7 @@ import {
   KeyboardDatePicker,
 } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
+import { useDataContext } from "./data_context";
 
 const useStyles = makeStyles({
   wideControl: {
@@ -68,6 +69,8 @@ export const IndividualDeath = ({ individual }: { individual: Individual }) => {
   const [success, setSuccess] = React.useState(false as boolean);
   const style = useStyles();
   const { userMessage } = useMessageContext();
+  const { herdListener, herdChangeListener, setHerdChangeListener } =
+    useDataContext();
 
   const getMinDate = () => {
     const lastTracking = new Date(individual.herd_tracking[0].date);
@@ -124,6 +127,9 @@ export const IndividualDeath = ({ individual }: { individual: Individual }) => {
     patch("/api/individual", deadIndividual).then((json) => {
       if (json.status == "success") {
         setSuccess(true);
+        if (deadIndividual.herd == herdListener) {
+          setHerdChangeListener(herdChangeListener + 1);
+        }
         return;
       }
       if (json.status == "error") {

--- a/frontend/src/individual_edit.tsx
+++ b/frontend/src/individual_edit.tsx
@@ -177,8 +177,14 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
   const [weightDate, setWeightDate] = React.useState(null as string | null);
   const [isSaveActive, setIsSaveActive] = React.useState(false);
   const { user } = useUserContext();
-  const { genebanks, colors } = useDataContext();
   const { userMessage, handleCloseDialog } = useMessageContext();
+  const {
+    genebanks,
+    colors,
+    herdListener,
+    herdChangeListener,
+    setHerdChangeListener,
+  } = useDataContext();
   const canManage: boolean = React.useMemo(() => {
     return user?.canEdit(individual?.genebank);
   }, [user, individual]);
@@ -454,6 +460,9 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
       (retval: ServerMessage) => {
         switch (retval.status) {
           case "success":
+            if (postData.herd.herd == herdListener) {
+              setHerdChangeListener(herdChangeListener + 1);
+            }
             userMessage(retval.message ?? "Individual updated", "success");
             handleCloseDialog();
             break;

--- a/frontend/src/individual_edit.tsx
+++ b/frontend/src/individual_edit.tsx
@@ -456,6 +456,7 @@ export function IndividualEdit({ id }: { id: string | undefined }) {
     if (isEqual(data, oldIndividual)) {
       return;
     }
+    const postData = { ...data };
     patch("/api/individual", data).then(
       (retval: ServerMessage) => {
         switch (retval.status) {

--- a/frontend/src/individual_sell.tsx
+++ b/frontend/src/individual_sell.tsx
@@ -142,7 +142,7 @@ export function IndividualSell({ individual }: { individual: Individual }) {
     };
     patch("/api/individual", limitedIndividual).then((json) => {
       if (json.status == "success") {
-        if (limitedIndividual.herd == herdListener) {
+        if (individual.herd_tracking[0].herd == herdListener) {
           setHerdChangeListener(herdChangeListener + 1);
         }
         setSuccess(true);

--- a/frontend/src/individual_sell.tsx
+++ b/frontend/src/individual_sell.tsx
@@ -77,7 +77,8 @@ export function IndividualSell({ individual }: { individual: Individual }) {
   const [checked, setChecked] = React.useState(false as boolean);
   const [invalidSale, setInvalidSale] = React.useState(false as boolean);
   const [success, setSuccess] = React.useState(false as boolean);
-  const { genebanks } = useDataContext();
+  const { genebanks, herdListener, herdChangeListener, setHerdChangeListener } =
+    useDataContext();
   const { userMessage } = useMessageContext();
   const style = useStyles();
   const disabled: boolean =
@@ -86,7 +87,7 @@ export function IndividualSell({ individual }: { individual: Individual }) {
 
   React.useEffect(() => {
     const currentGenebank = genebanks.find((genebank) =>
-      genebank.individuals.some((i) => i.number == individual.number)
+      genebank.individuals.some((i) => i.number[0] == individual.number[0])
     );
 
     setGenebank(currentGenebank);
@@ -141,6 +142,9 @@ export function IndividualSell({ individual }: { individual: Individual }) {
     };
     patch("/api/individual", limitedIndividual).then((json) => {
       if (json.status == "success") {
+        if (limitedIndividual.herd == herdListener) {
+          setHerdChangeListener(herdChangeListener + 1);
+        }
         setSuccess(true);
         return;
       }


### PR DESCRIPTION
If a user looks at a herd in herd view, the shown table in the tab "Lista över individer" will now update automatically as soon as one of the herd's individuals is updated, added or removed from the herd. 

To achieve that, the following changes were made:
- the `get_herd` function in `data_access.py` now sends more detailed information about a herd's individuals
- `herd_view.tsx` will take its information for the table of individuals from the herd instead of the big `genebanks`variable created on page load
- the `filter_table`was adjusted to be able to take in the information on `color` sent from the backend (in a different format as before). Also the table now can show digital certificate numbers.
- the tab "Lista över individer" will fetch herd data every time it's clicked
- the global `data_context` now has listeners for the herd the user is currently looking at as well as changes that are made to individuals in that herd. Changes can be made through
1. Editing an individual
2. issuing a digital certificate
3. updating a digital certificate
4. reporting an individual as dead
5. creating empty individuals when adding a breeding
6. selling an individual

All the components for these actions are now linked to the listener.

fixes #404 