### PR TITLE
Feature/fix is active

### DIFF
--- a/scripts/load-gotland.sh
+++ b/scripts/load-gotland.sh
@@ -128,8 +128,8 @@ psql --echo-errors --quiet <<-'END_SQL'
 			FROM genebank g, color_data c;
 
 	-- Dummy herd for individuals sold outside of the genebank
-	INSERT INTO herd (genebank_id, herd, herd_name)
-	SELECT	DISTINCT gb.genebank_id, 'GX1', 'Externa djur (Gotland)'
+	INSERT INTO herd (genebank_id, herd, herd_name, is_active)
+	SELECT	DISTINCT gb.genebank_id, 'GX1', 'Externa djur (Gotland)', false
 	FROM	genebank gb
 	WHERE	gb.name = 'Gotlandskanin';
 

--- a/scripts/load-gotland.sh
+++ b/scripts/load-gotland.sh
@@ -436,7 +436,8 @@ psql --quiet <<-'END_SQL'
 	)
 	FROM	genebank gb
 	WHERE	gb.genebank_id = h.genebank_id
-	AND	gb.name = 'Gotlandskanin';
+	AND	gb.name = 'Gotlandskanin'
+	AND	h.herd_name IS NULL;
 
 	-- Add herd active status
 	UPDATE herd h
@@ -448,7 +449,8 @@ psql --quiet <<-'END_SQL'
 	)
 	FROM	genebank gb
 	WHERE	gb.genebank_id = h.genebank_id
-	AND	gb.name = 'Gotlandskanin';
+	AND	gb.name = 'Gotlandskanin'
+	AND 	h.is_active IS NULL;
 
 	-- Add names of people responsible for the herd
 	UPDATE herd h
@@ -460,7 +462,8 @@ psql --quiet <<-'END_SQL'
 	)
 	FROM	genebank gb
 	WHERE	gb.genebank_id = h.genebank_id
-	AND	gb.name = 'Gotlandskanin';
+	AND	gb.name = 'Gotlandskanin'
+	AND	h.name IS NULL;
 
 	-- Add start date
 	UPDATE herd h
@@ -472,5 +475,6 @@ psql --quiet <<-'END_SQL'
 	)
 	FROM	genebank gb
 	WHERE	gb.genebank_id = h.genebank_id
-	AND	gb.name = 'Gotlandskanin';
+	AND	gb.name = 'Gotlandskanin'
+	AND	h.start_date IS NULL;
 END_SQL

--- a/scripts/load-mellerud.sh
+++ b/scripts/load-mellerud.sh
@@ -265,7 +265,8 @@ psql --quiet <<-'END_SQL'
 	)
 	FROM	genebank gb
 	WHERE	gb.genebank_id = h.genebank_id
-	AND	gb.name = 'Mellerudskanin';
+	AND	gb.name = 'Mellerudskanin'
+	AND	h.herd_name IS NULL;
 END_SQL
 
 if [ ! -f "$3" ]; then 

--- a/scripts/load-mellerud.sh
+++ b/scripts/load-mellerud.sh
@@ -273,6 +273,8 @@ if [ ! -f "$3" ]; then
     exit 0
 fi
 
+echo "Loading herds"
+
 # read the csv into a temprary table called 'm_data2'
 csvsql  --db "$1" -I \
 	--tables m_data2 \

--- a/scripts/load-mellerud.sh
+++ b/scripts/load-mellerud.sh
@@ -82,8 +82,8 @@ psql --echo-errors --quiet <<-'END_SQL'
       FROM genebank g, color_data c;
 
 	-- Dummy herd for individuals sold outside of the genebank
-	INSERT INTO herd (genebank_id, herd, herd_name)
-	SELECT	DISTINCT gb.genebank_id, 'MX1', 'Externa djur (Mellerud)'
+	INSERT INTO herd (genebank_id, herd, herd_name, is_active)
+	SELECT	DISTINCT gb.genebank_id, 'MX1', 'Externa djur (Mellerud)', false
 	FROM	genebank gb
 	WHERE	gb.name = 'Mellerudskanin';
 


### PR DESCRIPTION
This sets the `is_active` attribute for the GX1 and MX1 herds to `false`.  The commits also fixes an oversight that made the later parts of the loading scripts overwrite some herd-related info that was set earlier.

This is related to issue #424 