### PR TITLE
Fix/breedform parents

### DIFF
--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -490,13 +490,18 @@ export function BreedingForm({
                 newValue && setFormField("mother", newValue.number);
               }}
             />
-            <Button
-              color="primary"
-              onClick={() => setShowFromDateFilter(!showFromDateFilter)}
-            >
-              {showFromDateFilter == false ? "Filtrera hanar" : "Dölj"}
-              {showFromDateFilter == false ? <ExpandMore /> : <ExpandLess />}
-            </Button>
+            {genebank &&
+            (user?.is_admin || user?.is_manager?.includes(genebank.id)) ? (
+              <></>
+            ) : (
+              <Button
+                color="primary"
+                onClick={() => setShowFromDateFilter(!showFromDateFilter)}
+              >
+                {showFromDateFilter == false ? "Filtrera hanar" : "Dölj"}
+                {showFromDateFilter == false ? <ExpandMore /> : <ExpandLess />}
+              </Button>
+            )}
             {showFromDateFilter ? (
               <>
                 <KeyboardDatePicker

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -75,8 +75,12 @@ export function BreedingForm({
   let defaultDate = new Date();
   defaultDate.setFullYear(defaultDate.getFullYear() - 10);
   const [fromDate, setFromDate] = React.useState(defaultDate as Date);
-  const [activeMalesLimited, setActiveMalesLimited] = React.useState([]);
-  const [activeFemalesLimited, setActiveFemalesLimited] = React.useState([]);
+  const [activeMalesLimited, setActiveMalesLimited] = React.useState(
+    [] as LimitedIndividual[]
+  );
+  const [activeFemalesLimited, setActiveFemalesLimited] = React.useState(
+    [] as LimitedIndividual[]
+  );
   const [showFromDateFilter, setShowFromDateFilter] = React.useState(false);
 
   const genebank: Genebank | undefined = React.useMemo(() => {
@@ -89,17 +93,21 @@ export function BreedingForm({
   );
 
   React.useEffect(() => {
-    setActiveFemalesLimited(
-      toLimitedIndividuals(
-        individualsFromDate(genebank, "female", fromDate, herdId)
-      )
-    );
-    setActiveMalesLimited(
-      toLimitedIndividuals(
-        individualsFromDate(genebank, "male", fromDate, undefined)
-      )
-    );
-  }, [fromDate, genebank]);
+    let females = individualsFromDate(genebank, "female", fromDate, herdId);
+    let males = individualsFromDate(genebank, "male", fromDate, undefined);
+    if (!!data && data !== "new") {
+      const mother = genebank?.individuals.find((i) => i.number == data.mother);
+      const father = genebank?.individuals.find((i) => i.number == data.father);
+      if (!!mother && !!father) {
+        females.push(mother);
+        males.push(father);
+      }
+    }
+    const limitedFemales = toLimitedIndividuals(females);
+    const limitedMales = toLimitedIndividuals(males);
+    setActiveFemalesLimited(limitedFemales);
+    setActiveMalesLimited(limitedMales);
+  }, [fromDate, genebank, data]);
 
   /**
    * Sets a single key `label` in the `herd` form to `value` (if herd isn't

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -109,8 +109,16 @@ export function BreedingForm({
       males = individualsFromDate(genebank, "male", fromDate, undefined);
     }
     if (!!data && data !== "new") {
-      const mother = genebank?.individuals.find((i) => i.number == data.mother);
-      const father = genebank?.individuals.find((i) => i.number == data.father);
+      const activeMother = females.find((i) => i.number === data.mother);
+      let mother;
+      if (!activeMother) {
+        mother = genebank?.individuals.find((i) => i.number === data.mother);
+      }
+      const activeFather = males.find((i) => i.number === data.father);
+      let father;
+      if (!activeFather) {
+        father = genebank?.individuals.find((i) => i.number === data.father);
+      }
       if (!!mother && !!father) {
         females.push(mother);
         males.push(father);

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -31,6 +31,7 @@ import { Autocomplete } from "@material-ui/lab";
 import { ExpandMore, ExpandLess } from "@material-ui/icons";
 import { get, patch, post } from "./communication";
 import { useBreedingContext } from "./breeding_context";
+import { useUserContext } from "./user_context";
 
 const emptyBreeding: Breeding = {
   id: -1,
@@ -70,6 +71,7 @@ export function BreedingForm({
     checkBirthUpdate,
   } = useBreedingContext();
   const { userMessage } = useMessageContext();
+  const { user } = useUserContext();
   const [formState, setFormState] = React.useState(emptyBreeding as Breeding);
   const [showBirthForm, setShowBirthForm] = React.useState(false);
   let defaultDate = new Date();
@@ -93,8 +95,19 @@ export function BreedingForm({
   );
 
   React.useEffect(() => {
-    let females = individualsFromDate(genebank, "female", fromDate, herdId);
-    let males = individualsFromDate(genebank, "male", fromDate, undefined);
+    let females: Individual[] = [];
+    let males: Individual[] = [];
+    if (
+      genebank &&
+      data !== "new" &&
+      (user?.is_admin || user?.is_manager?.includes(genebank.id))
+    ) {
+      females = genebank?.individuals.filter((i) => i.sex === "female");
+      males = genebank?.individuals.filter((i) => i.sex === "male");
+    } else {
+      females = individualsFromDate(genebank, "female", fromDate, herdId);
+      males = individualsFromDate(genebank, "male", fromDate, undefined);
+    }
     if (!!data && data !== "new") {
       const mother = genebank?.individuals.find((i) => i.number == data.mother);
       const father = genebank?.individuals.find((i) => i.number == data.father);


### PR DESCRIPTION
For Owners:
If you look at an existing breeding event, mother and father will show up the form even if they are not active any more. 
To achieve that, they are manually added to the respective option arrays for females / males that are used in the form's dropdowns.

For admins & managers:
If you edit a breeding you see all males and females, even inactive and dead in the dropdown.
If you add a new one, you still only see the ones currently active for the herd the breeding event belongs to.
