### PR TITLE
Remove birth date bug in edit individual

### DIFF
--- a/frontend/src/data_context_global.tsx
+++ b/frontend/src/data_context_global.tsx
@@ -154,7 +154,7 @@ export function breedingLabel(individual: Individual): string {
   let mother = `${individual.mother.number}`;
   let testDate = new Date(individual.birth_date).toString();
   if (testDate == "Invalid Date") {
-    return "Väntar på giltig födelsedatum......";
+    return "Väntar på giltigt födelsedatum......";
   }
   let date = new Date(individual.birth_date)?.toISOString().split("T")[0];
   return (

--- a/frontend/src/data_context_global.tsx
+++ b/frontend/src/data_context_global.tsx
@@ -152,8 +152,25 @@ export function individualLabel(individual: LimitedIndividual): string {
 export function breedingLabel(individual: Individual): string {
   let father = `${individual.father.number}`;
   let mother = `${individual.mother.number}`;
+  let testDate = new Date(individual.birth_date).toString();
+  if (testDate == "Invalid Date") {
+    return "Väntar på giltig födelsedatum......";
+  }
   let date = new Date(individual.birth_date)?.toISOString().split("T")[0];
-   return "[" + "Födsel " + date + "] " + father + "(" + individual.father.name +  ") - " + mother + "(" + individual.mother.name + ")";
+  return (
+    "[" +
+    "Födsel " +
+    date +
+    "] " +
+    father +
+    "(" +
+    individual.father.name +
+    ") - " +
+    mother +
+    "(" +
+    individual.mother.name +
+    ")"
+  );
 }
 
 export function herdLabel(herd: LimitedHerd): string {


### PR DESCRIPTION
The birth date picker in edit individual did throw errors as soon as one started changing the date input manually.
The reason for that was a function in data_context_global that uses the birth date variable with the date method `toISOstring`.
Manually editing the birth date in the form gave (temporarily) invalid date strings.

This PR makes sure the `toISOstring` method is only called on valid date strings.

fixes #441 