### PR TITLE
Get breeding event of created individual of the current year

### DIFF
--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -412,8 +412,18 @@ def next_individual_number(herd, birth_date, breeding_event):
         events = (
             Breeding.select(Breeding.id)
             .join(Individual, on=(Breeding.id == Individual.breeding))
-            .join(Herd, on=(Herd.id == Individual.origin_herd))
+            .join(HerdTracking, on=(HerdTracking.individual == Individual.id))
+            .join(Herd, on=(Herd.id == HerdTracking.herd))
             .where((Herd.herd == herd))
+            .where(
+                (
+                    DATABASE.extract_date("year", HerdTracking.herd_tracking_date)
+                    == birth_date.year
+                )
+            )
+            .where(
+                (DATABASE.extract_date("year", Breeding.birth_date) == birth_date.year)
+            )
             .distinct()
         ).execute()
 


### PR DESCRIPTION
Next individual number will look for individuals that was born in the current herd during the birth year of the new individual we want to add and figure out the litter number.

To get this to work a user need to register the births and create individual in the right order. 
Maybe we could figure out and order the births so they get the right number since it s the order of births thats is important but that means wee need a way to update already created individuals and that could bee tricky.

This closes #440 

