### PR TITLE
Fix Auth dance with google and Google login as default

### DIFF
--- a/app/herdbook.py
+++ b/app/herdbook.py
@@ -408,7 +408,7 @@ def external_login_handler(service):
         return "null"  # bad method
 
     if not session.get("link_account") and current_user.is_authenticated:
-        return get_user()
+        return redirect(request.referrer or "/")
 
     if not utils.external_auth.authorized(APP, service):
         APP.logger.debug("Need to do external auth for service %s" % service)
@@ -430,7 +430,7 @@ def external_login_handler(service):
         session["user_id"] = user.uuid
         session.modified = True
         login_user(user)
-        return get_user()
+        return redirect(request.referrer or "/")
 
     if not utils.external_auth.get_autocreate(service):
         # No user - give up
@@ -493,7 +493,7 @@ def external_login_handler(service):
 
     login_user(user)
 
-    return get_user()
+    return redirect("/start")
 
 
 @APP.route("/api/link/<string:service>", methods=["GET", "POST"])

--- a/frontend/src/login.tsx
+++ b/frontend/src/login.tsx
@@ -3,7 +3,6 @@ import { useHistory, useLocation } from "react-router-dom";
 
 import { CircularProgress } from "@material-ui/core";
 import Button from "@material-ui/core/Button";
-import Container from "@material-ui/core/Container";
 import TextField from "@material-ui/core/TextField";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
@@ -11,9 +10,6 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
 
-import { useMessageContext } from "@app/message_context";
-
-import { post, get } from "@app/communication";
 import { useUserContext } from "@app/user_context";
 import { inputVariant } from "@app/data_context_global";
 
@@ -25,8 +21,6 @@ export function Login() {
   const { user, login } = useUserContext();
   const [username, set_username] = useState("");
   const [password, set_password] = useState("");
-  const [authenticators, setAuthenticators] = useState([]);
-  const { userMessage } = useMessageContext();
 
   const history = useHistory();
   const location = useLocation();
@@ -47,9 +41,6 @@ export function Login() {
     }
   }, [user]);
 
-  React.useEffect(() => {
-    getAvailableAuthenticators();
-  }, []);
 
   const keydown = (e: React.KeyboardEvent<any>) => {
     // Cannot get TextField to trigger onSubmit so listen for keydown instead
@@ -57,98 +48,6 @@ export function Login() {
       submitLogin();
     }
   };
-
-  if (user != null) {
-    return (
-      <div className="loading">
-        <CircularProgress />
-      </div>
-    );
-  }
-
-  function waitForExternalLogin(w) {
-    // Wait for an external login window
-    try {
-      if (w.document.readyState == "complete") {
-        var returnedUser = w.document.body.innerText.trim();
-        if (returnedUser == "null") {
-          userMessage("Identity not linked to any known user", "error");
-        } else {
-          userMessage("Logged in as " + returnedUser, "success");
-          document.location = "/";
-        }
-
-        w.close();
-        return;
-      }
-    } catch (err) {}
-    setTimeout(() => waitForExternalLogin(w), 100);
-  }
-
-  function authenticateExternal(service) {
-    // We are not doing account linking
-    fetch("/api/link/reset", {
-      body: "",
-      method: "POST",
-      credentials: "same-origin",
-      redirect: "manual",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
-    })
-      .then((x) => {
-        // Authenticate with external service service
-
-        return fetch("/api/login/" + service, {
-          body: "",
-          method: "POST",
-          credentials: "same-origin",
-          redirect: "manual",
-          headers: {
-            Accept: "application/json",
-            "Content-Type": "application/json",
-          },
-        });
-      })
-      .then(
-        (response) => {
-          if (response.ok) {
-            response.json().then((data) => {
-              if (data == null) {
-                userMessage("Identity not linked to any known user", "error");
-              } else {
-                userMessage(
-                  "Logged in as " + data["username"]
-                    ? data["username"]
-                    : data["email"],
-                  "success"
-                );
-                document.location = "/";
-              }
-            });
-          } else {
-            var w = window.open("/api/login/" + service, "_blank");
-            setTimeout(() => waitForExternalLogin(w), 20);
-          }
-        },
-        (err) => {
-          userMessage("Unexpected error", "error");
-        }
-      );
-  }
-
-  async function getAvailableAuthenticators(l) {
-    await post("/api/login/available").then(
-      (data) => {
-        if (!data) {
-          data = [];
-        }
-        setAuthenticators(data);
-      },
-      (error) => {}
-    );
-  }
 
   return user === null ? (
     <Dialog open={open} onClose={close} aria-labelledby="form-dialog-title">
@@ -188,19 +87,6 @@ export function Login() {
           <Button onClick={submitLogin} color="primary" aria-label="Logga in">
             Logga in
           </Button>
-        </DialogActions>
-        <DialogActions>
-          <Container>
-            {authenticators.map((item) => (
-              <Button
-                onClick={() => authenticateExternal(item)}
-                key={item}
-                name={item}
-              >
-                {item}
-              </Button>
-            ))}
-          </Container>
         </DialogActions>
       </form>
     </Dialog>

--- a/frontend/src/owner.tsx
+++ b/frontend/src/owner.tsx
@@ -33,6 +33,12 @@ export function Owner() {
   );
   const style = useStyles();
 
+  React.useEffect(() => {
+    if (user && user.is_owner) {
+      setActiveHerd(user.is_owner[0])
+    }
+  }, [user])
+
   return (
     <>
       <Paper className={style.container}>

--- a/frontend/src/register.tsx
+++ b/frontend/src/register.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useDataContext } from "@app/data_context";
 
 import { Genebank } from "@app/data_context_global";
-import { Button, Paper, makeStyles } from "@material-ui/core";
+import { Button, Paper, makeStyles, CircularProgress } from "@material-ui/core";
 
 import { Link, useRouteMatch, useHistory } from "react-router-dom";
 import { GenebankView } from "@app/genebank_view";
@@ -45,7 +45,7 @@ export function Register() {
 
   return (
     <>
-      {!!(user?.is_manager || user?.is_admin) ? (
+      {!!((user?.is_manager && genebank) || (user?.is_admin && genebank)) ? (
         <Paper>
           <div className={styles.buttonBar}>
             {genebanks.length > 1 &&
@@ -65,13 +65,15 @@ export function Register() {
                 );
               })}
           </div>
-          {React.useMemo(
-            () => genebank && <IndividualAdd genebank={genebank} />,
-            [genebank]
-          )}
+          <IndividualAdd genebank={genebank} />
         </Paper>
-      ) : (
+      ) : user && !user.is_admin && !user.is_manager ? (
         <p>Du har inte rättigheterna att registrera nya kaniner.</p>
+      ) : (
+        <div className="loading">
+          <h2>Laddar...</h2>
+          <CircularProgress />
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
Fixes the auth dance so no need to open a new window. 
Google is now default
If you want to log in using a username password please access /admin

This also fixes #178 the reload showing login window bug. When reloading a page the user context is not loaded until on_mount of a component. The changes here check the API backend if no user context exists and let the user see the page if it is actually logged in the backend. 

Some minor changes to text on-page. When linking google ID to the user account the first time the user is redirected to a "start" page that currently does not exist.
