### PR TITLE
Allow the secondary domain to be able to login

### DIFF
--- a/app/utils/external_auth.py
+++ b/app/utils/external_auth.py
@@ -129,6 +129,7 @@ def setup_google(app, config):
     if config["google"].get("domain", None):
         hdparam["hosted_domain"] = config["google"]["domain"]
         _config["googledomain"] = config["google"]["domain"]
+        _config["second_googledomain"] = config["google"]["second_domain"]
 
     if config["google"].get("herdattribute", None):
         _config["googleherd"] = config["google"]["herdattribute"]
@@ -183,7 +184,10 @@ def google_authorized():
         return False
 
     if "googledomain" in _config:
-        if "hd" not in idtoken or idtoken["hd"] != _config["googledomain"]:
+        if "hd" not in idtoken or (
+            idtoken["hd"] != _config["googledomain"]
+            and idtoken["hd"] != _config["second_googledomain"]
+        ):
             return None
 
     return flask_dance.contrib.google.google.authorized

--- a/config/auth.ini.sample
+++ b/config/auth.ini.sample
@@ -1,0 +1,9 @@
+[google]
+key=
+secret=
+domain=gotlandskaninen.se
+second_domain=mellerudskaninen.se
+autocreate = yes
+credentialsfile=
+lookupuser=
+herdattribute=externalIds


### PR DESCRIPTION
This wont affect the UI adding the hd_domain in the login input. since only one domain is supported by google