### PR TITLE
fix so we do not redirect to myaccount.google for the first login

### DIFF
--- a/app/herdbook.py
+++ b/app/herdbook.py
@@ -424,12 +424,21 @@ def external_login_handler(service):
 
     if user:
         APP.logger.info(
-            "Logging in user %s (%s - #%d) by persistent id %s for service %s"
-            % (user.username, user.email, user.id, persistent_id, service)
+            "Logging in user %s (%s - #%d) by persistent id %s for service %s, refferrer is %s"
+            % (
+                user.username,
+                user.email,
+                user.id,
+                persistent_id,
+                service,
+                request.referrer,
+            )
         )
         session["user_id"] = user.uuid
         session.modified = True
         login_user(user)
+        if "accounts.google" in request.referrer:
+            return redirect("/")
         return redirect(request.referrer or "/")
 
     if not utils.external_auth.get_autocreate(service):


### PR DESCRIPTION
Before When a user is logging in with its google account and the user is not already logged in at Google 
we redirect the user to accounts.google.[com|se] 
now we check for that and redirect to root "/"