### PR TITLE
the python code should always be refreshed without editing a file

### DIFF
--- a/system/supervisord.conf
+++ b/system/supervisord.conf
@@ -53,7 +53,7 @@ stdout_logfile_maxbytes = 0
 stderr_logfile_maxbytes = 0
 
 [program:extra_loader]
-command=bash -c 'test -d /config/updates && while true; do inotifywait -e modify,attrib,create,delete -r -q /config/updates; rsync -a /config/updates/ /app/dist/; done'
+command=bash -c 'rsync -a /config/updates/ /app/dist/ && test -d /config/updates && while true; do inotifywait -e modify,attrib,create,delete -r -q /config/updates; rsync -a /config/updates/ /app/dist/; done'
 user=www-data
 directory=/tmp
 stderr_logfile = /dev/stdout


### PR DESCRIPTION
To test it you can for example, stop the containers, add a print a line in  theherdbook.py file: 

print("I am refreshed!!!!!!!!!!!!!!!!!!!!!!")

and start the containers. You should see the line printed in the logs.
This fix avoids having to edit a file to reload the python code when restarting the containers.