### PR TITLE
fixing python hot reload

### DIFF
--- a/system/supervisord.conf
+++ b/system/supervisord.conf
@@ -1,5 +1,6 @@
 [unix_http_server]
 file=/tmp/supervisor.sock                       ; path to your socket file
+chmod=0766
 
 [supervisord]
 logfile=/dev/stdout

--- a/system/supervisord.conf
+++ b/system/supervisord.conf
@@ -35,7 +35,7 @@ stdout_logfile_maxbytes = 0
 stderr_logfile_maxbytes = 0
 
 [program:uwsgi_reloader]
-command=bash -c 'while true; do inotifywait -e modify,attrib,create,delete -r -q /api_src; rsync -a /api_src/ /code/; pkill -HUP uwsgi; done'
+command=bash -c 'rsync -a /api_src/ /code/ && supervisorctl restart uwsgi && while true; do inotifywait -e modify,attrib,create,delete -r -q /api_src; rsync -a /api_src/ /code/; pkill -HUP uwsgi; done'
 user=www-data
 directory=/code
 stderr_logfile = /dev/stdout
@@ -53,7 +53,7 @@ stdout_logfile_maxbytes = 0
 stderr_logfile_maxbytes = 0
 
 [program:extra_loader]
-command=bash -c 'rsync -a /config/updates/ /app/dist/ && test -d /config/updates && while true; do inotifywait -e modify,attrib,create,delete -r -q /config/updates; rsync -a /config/updates/ /app/dist/; done'
+command=bash -c 'test -d /config/updates && while true; do inotifywait -e modify,attrib,create,delete -r -q /config/updates; rsync -a /config/updates/ /app/dist/; done'
 user=www-data
 directory=/tmp
 stderr_logfile = /dev/stdout


### PR DESCRIPTION
The hotreload fix needed to be done in the uwsgi_reloader. To test it:
stop the containers, add or edit a log, for example:
APP.logger.info("Connecting to database!!!!"),
start the containers and check if the updated log is printed. 
The python code is now refreshed when starting the container.