### PR TITLE
add info card to herd form and fix styling

### DIFF
--- a/frontend/src/herdForm.tsx
+++ b/frontend/src/herdForm.tsx
@@ -447,6 +447,29 @@ export function HerdForm({
                       </Typography>
                     </div>
                   </MuiPickersUtilsProvider>
+                  <div className="formCard formInfoCard">
+                    <Typography className="subheading">
+                      Du bestämmer över dina uppgifter
+                    </Typography>
+                    <p>
+                      Du som är genbanksinnehavare fyller själv i de
+                      kontaktuppgifter du vill att andra genbanker ska se för
+                      att underlätta kommunikation mellan genbankerna. Du kan
+                      själv, när som helst, gå in och ändra i dina
+                      kontaktuppgifter.
+                    </p>
+                    <Typography className="subheading">
+                      OBS! Tänk på medlemsmatrikeln
+                    </Typography>
+                    <p>
+                      En ändring här slår inte igenom till föreningens
+                      medlemsmatrikel, så om du exempelvis flyttat eller bytt
+                      e-post, måste du också meddela det till föreningens
+                      kassör, för ändring i medlemsmatrikeln. Medlemsmatrikeln
+                      används bara för föreningens interna administration, och
+                      är inte offentlig.
+                    </p>
+                  </div>
                 </form>
                 <Button
                   variant="contained"

--- a/frontend/src/herdForm.tsx
+++ b/frontend/src/herdForm.tsx
@@ -452,9 +452,9 @@ export function HerdForm({
                       Du bestämmer över dina uppgifter
                     </Typography>
                     <p>
-                      Du som är genbanksinnehavare fyller själv i de
-                      kontaktuppgifter du vill att andra genbanker ska se för
-                      att underlätta kommunikation mellan genbankerna. Du kan
+                      Du som är besättningsinnehavare fyller själv i de
+                      kontaktuppgifter du vill att andra besättningar ska se för
+                      att underlätta kommunikation mellan besättningarna. Du kan
                       själv, när som helst, gå in och ändra i dina
                       kontaktuppgifter.
                     </p>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -243,11 +243,14 @@ list-item {
 .herdForm {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 
 /* Used in herdForm.tsx and field_with_permission.tsx */
 .simpleField {
   width: 100%;
+  margin-right: 20px;
+  min-width: 222px;
 }
 
 /* Used in herdForm.tsx */
@@ -268,9 +271,16 @@ list-item {
 .formCard {
   padding: 15px;
   margin: 10px;
-  max-width: 450px;
+  max-width: 475px;
   border: 1px solid grey;
   border-radius: 5px;
+}
+
+/* Used in herdForm.tsx */
+.formInfoCard {
+  flex-shrink: 1;
+  flex-grow: 1;
+  flex-basis: 200px;
 }
 
 /* Used in herdForm.tsx */
@@ -313,9 +323,8 @@ list-item {
 
 /*  Used in field_with_permission.tsx */
 .permissionFieldExtended {
-  width: 200px;
+  min-width: 200px;
   margin-top: 0;
-  margin-left: 45px;
 }
 
 /*  Used in genebanks.tsx, register.tsx and testbreed_form.tsx */


### PR DESCRIPTION
I added the info text as a box in herd form. 
It's rendered to the right of the forms boxes. 
If there is not enough space, it will wrap to below.

I also changed the styling slightly to make the first form box look better. 

This fixes #412 