### PR TITLE
Fix/reset selling herd

### DIFF
--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -427,7 +427,8 @@ def next_individual_number(herd, birth_date, breeding_event):
                 fn.COALESCE(
                     Breeding.birth_date,
                     Breeding.breed_date + 30,
-                )
+                ),
+                Breeding.id,
             ]
         )
         events = (

--- a/frontend/src/individual_add.tsx
+++ b/frontend/src/individual_add.tsx
@@ -212,7 +212,6 @@ export function IndividualAdd({
       if (!mother) {
         return;
       }
-      console.log("Mother get is", mother);
       let herds = mother.herd_tracking;
 
       if (herds.length > 0) {
@@ -357,8 +356,8 @@ export function IndividualAdd({
           getIndnumbSuggestion(limitedBreedingInput);
         }
       } else if (
-        individual?.origin_herd.herd === "GX1" ||
-        individual?.origin_herd.herd === "MX1"
+        individual?.origin_herd?.herd === "GX1" ||
+        individual?.origin_herd?.herd === "MX1"
       ) {
         handleUpdateIndividual("number", null);
       }
@@ -549,7 +548,6 @@ export function IndividualAdd({
   const getIndnumbSuggestion = async (
     BreedingMatch: Breeding | LimitedBreeding
   ) => {
-    console.log(BreedingMatch);
     post(`/api/breeding/nextind/`, BreedingMatch).then(
       (json) => {
         switch (json.status) {

--- a/frontend/src/individual_form.tsx
+++ b/frontend/src/individual_form.tsx
@@ -89,6 +89,19 @@ export function IndividualForm({
           label: `${c.id} - ${c.name}`,
         };
       });
+    } else if (
+      individual &&
+      colors &&
+      Object.keys(colors).includes(individual.genebank)
+    ) {
+      return colors[individual.genebank].map((c) => {
+        return {
+          id: c.id,
+          comment: c.comment,
+          value: c.name,
+          label: `${c.id} - ${c.name}`,
+        };
+      });
     }
     return [];
   }, [colors, genebank]);

--- a/frontend/src/individual_sellingform.tsx
+++ b/frontend/src/individual_sellingform.tsx
@@ -52,7 +52,9 @@ export function IndividualSellingForm({
       <Autocomplete
         key={herdKey}
         options={herdOptions}
-        value={herdOptions.find((option) => option.herd == individual.herd)}
+        value={
+          herdOptions.find((option) => option.herd == individual.herd) ?? null
+        }
         getOptionLabel={(option: LimitedHerd) => herdLabel(option)}
         renderInput={(params) => (
           <TextField


### PR DESCRIPTION
A fix to reset selling herd Autocomplete when resetting the form.
It also includes a minor fix for the number suggestion on how to order the litter number when birth date is the same 