### PR TITLE
Fixes for Genebank logging

### DIFF
--- a/app/utils/genebank_logging.py
+++ b/app/utils/genebank_logging.py
@@ -4,10 +4,11 @@ Things for logging updates to rabbit per year and genebank
 """
 # pylint: disable=too-many-lines
 import logging
-import os
 from logging.handlers import TimedRotatingFileHandler
 
 from flask import has_request_context, request
+
+logger = logging.getLogger("herdbook.genbanklogging")
 
 
 class RequestFormatter(logging.Formatter):
@@ -26,20 +27,30 @@ class MyTimedRotatingFileHandler(TimedRotatingFileHandler):
     def __init__(self, logfile, when):
         super(MyTimedRotatingFileHandler, self).__init__(logfile, when)
         self._header = ""
+        self.formatter = logging.Formatter(
+            "%(asctime)s,%(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+        )
         self._log = None
 
     def write_header(self):
         if self._log is not None and self._header != "":
+            self.formatter = logging.Formatter(None)
             self._log.info(self._header)
+            self.formatter = logging.Formatter(
+                "%(asctime)s,%(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+            )
 
     def doRollover(self):
         super(MyTimedRotatingFileHandler, self).doRollover()
         self.write_header()
+        logger.info("Rotating logs %s", self.baseFilename)
 
     def configureHeaderWriter(self, header, log):
         self._header = header
         self._log = log
-        self.write_header()  # WRITE HEADER TO FIRST FILE
+
+    #   Skip this line otherwise header is written twice.
+    #   self.write_header()  # WRITE HEADER TO FIRST FILE
 
 
 def create_genebank_logs(first_path, first_log_name):
@@ -47,26 +58,20 @@ def create_genebank_logs(first_path, first_log_name):
         log_name = f"{first_log_name}_{log_type}"
         path = f"{first_path}{log_name}.csv"
         logger = logging.getLogger(log_name)
-        formatter = logging.Formatter(
-            "%(asctime)s,%(message)s", datefmt="%Y-%m-%d %H:%M:%S"
-        )
-        logger.setLevel(logging.INFO)
-        fileExists = True
-        if not os.path.isfile(path):
-            fileExists = False
-
         handler = MyTimedRotatingFileHandler(path, when="W6")
         logger.addHandler(handler)
-        # only add header if file did not exist before.
-        if not fileExists:
-            if log_type == "update":
-                handler.configureHeaderWriter(
-                    "datum,användare,individ.number,fält,gammalt,nytt,sälj/rapport-datum",
-                    logger,
-                )
-            if log_type == "create":
-                handler.configureHeaderWriter(
-                    "datum,användare,individ.number,individ.namn,besättning,sälj-datum",
-                    logger,
-                )
-        handler.setFormatter(formatter)
+        if log_type == "update" or log_type == "create":
+            handler.namer = lambda name: name + ".csv"
+        else:
+            handler.namer = lambda name: name + ".log"
+
+        if log_type == "update":
+            handler.configureHeaderWriter(
+                "datum,användare,individ.number,fält,gammalt,nytt,sälj/rapport-datum",
+                logger,
+            )
+        if log_type == "create":
+            handler.configureHeaderWriter(
+                "datum,användare,individ.number,individ.namn,besättning,sälj-datum",
+                logger,
+            )


### PR DESCRIPTION
This fixes the suffix of log files.
Also fixes the missing header and the header is now written without formatter.
Also, log to the root logger when doing a rollover. 

