### PR TITLE
fix(certificates): PDF text not visible in Microsoft Edge

### DIFF
--- a/app/utils/certificates.py
+++ b/app/utils/certificates.py
@@ -207,14 +207,21 @@ class CertificateGenerator:
                         widget.field_value = val
                     widget.update()
                     xref = widget.xref
-                    ap_entry = doc.xref_get_key(xref, "AP")
-                    if ap_entry[0] == "dict" and "/N " in ap_entry[1]:
-                        n_xref = int(ap_entry[1].split("/N ")[1].split(" ")[0])
-                        stream = doc.xref_stream(n_xref)
-                        if stream:
-                            patched = re.sub(rb"(\n)0 ([0-9.]+) Td", rb"\g<1>2 \2 Td", stream)
-                            if patched != stream:
-                                doc.update_stream(n_xref, patched)
+                    n_obj = doc.xref_get_key(xref, "AP/N")
+                    if n_obj[0] == "indirect":
+                        try:
+                            n_xref = int(n_obj[1].split()[0])
+                            stream = doc.xref_stream(n_xref)
+                            if stream:
+                                patched = re.sub(
+                                    rb"(\n)0 ([0-9.]+) Td",
+                                    rb"\g<1>2 \2 Td",
+                                    stream,
+                                )
+                                if patched != stream:
+                                    doc.update_stream(n_xref, patched)
+                        except (ValueError, IndexError):
+                            logger.debug("Skipped AP/N patching for widget %s", widget.field_name)
                     widget = widget.next
             doc.save(out)
         out.seek(0)

--- a/app/utils/certificates.py
+++ b/app/utils/certificates.py
@@ -1,8 +1,10 @@
 """
 PDF certificate handler
 """
+
 import datetime
 import logging
+import re
 from io import BytesIO
 from pathlib import Path
 
@@ -131,13 +133,12 @@ class CertificateGenerator:
                         if form_key:
                             val = form_data.get(form_key, "")
                             vals = self._encode_pdf_string(val)
-                            annotation.update(pdfrw.PdfDict(AP=vals, V=vals, Ff=1))
+                            annotation.update(pdfrw.PdfDict(V=vals, Ff=1))
 
-        reader.Root.AcroForm.update(
-            pdfrw.PdfDict(NeedAppearances=pdfrw.PdfObject("true"))
-        )
+        reader.Root.AcroForm.update(pdfrw.PdfDict(NeedAppearances=pdfrw.PdfObject("false")))
         buffered = BytesIO()
         writer.write(buffered, reader)
+        buffered = self._generate_appearances(buffered)
         return buffered
 
     @staticmethod
@@ -188,6 +189,36 @@ class CertificateGenerator:
                         key = annotation["/T"][1:-1]
                         annots.append(key)
         return annots
+
+    @staticmethod
+    def _generate_appearances(pdf_bytes):
+        """Use PyMuPDF to generate proper appearance streams for all form
+        widgets so the PDF renders correctly in all viewers including Edge."""
+        if hasattr(pdf_bytes, "seek"):
+            pdf_bytes.seek(0)
+        out = BytesIO()
+        with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+            for page in doc:
+                widget = page.first_widget
+                while widget:
+                    widget.border_width = 0
+                    val = widget.field_value
+                    if val is not None:
+                        widget.field_value = val
+                    widget.update()
+                    xref = widget.xref
+                    ap_entry = doc.xref_get_key(xref, "AP")
+                    if ap_entry[0] == "dict" and "/N " in ap_entry[1]:
+                        n_xref = int(ap_entry[1].split("/N ")[1].split(" ")[0])
+                        stream = doc.xref_stream(n_xref)
+                        if stream:
+                            patched = re.sub(rb"(\n)0 ([0-9.]+) Td", rb"\g<1>2 \2 Td", stream)
+                            if patched != stream:
+                                doc.update_stream(n_xref, patched)
+                    widget = widget.next
+            doc.save(out)
+        out.seek(0)
+        return out
 
     @staticmethod
     def _encode_pdf_string(value):

--- a/app/utils/certificates.py
+++ b/app/utils/certificates.py
@@ -208,7 +208,7 @@ class CertificateGenerator:
                     widget.update()
                     xref = widget.xref
                     n_obj = doc.xref_get_key(xref, "AP/N")
-                    if n_obj[0] == "indirect":
+                    if n_obj[0] == "xref":
                         try:
                             n_xref = int(n_obj[1].split()[0])
                             stream = doc.xref_stream(n_xref)


### PR DESCRIPTION
## Summary

- **Bug:** Certificate PDFs show no text when opened in Microsoft Edge on Windows
- **Root cause:** `pdfrw` form filling set the `/AP` (Appearance) entry to a raw text string instead of a proper appearance stream dictionary. Edge's PDF viewer couldn't parse the invalid data and rendered blank fields. Chrome/Adobe were more forgiving and fell back to `NeedAppearances` regeneration.
- **Fix:** Remove the malformed `AP=vals` from pdfrw form filling, set `NeedAppearances=false`, and add a post-processing step using PyMuPDF (`fitz`) to generate correct appearance streams for all form widgets via `widget.update()`. Widget borders are suppressed (`border_width=0`) and text gets 2px left padding via AP stream patching to match the original certificate layout.

## Changes

In `app/utils/certificates.py`:
1. Removed `AP=vals` from annotation update — only set `V` (value) and `Ff` (flags)
2. Set `NeedAppearances=false` so viewers use provided AP streams (also protects digital signature integrity)
3. Added `_generate_appearances()` static method that generates proper AP streams, suppresses borders, and restores text padding

## Test plan

- [ ] Generate a certificate PDF and open it in Microsoft Edge on Windows — text should be visible
- [ ] Verify certificate still renders correctly in Chrome and Adobe Reader
- [ ] Verify QR code is still present and positioned correctly
- [ ] Verify digital signature still validates after the change