### PR TITLE
fix(frontend): back-port production-only frontend fixes to develop

### DIFF
--- a/frontend/src/SelectGenebankStep.tsx
+++ b/frontend/src/SelectGenebankStep.tsx
@@ -29,7 +29,7 @@ export const SelectGenebankStep: React.FC<SelectGenebankStepProps> = ({
     if (user.is_admin) {
       return true;
     }
-    if (user.is_manager) {
+    if (user.is_manager?.length > 0) {
       return user.is_manager.includes(g.id);
     }
     return false;

--- a/frontend/src/SelectGenebankStep.tsx
+++ b/frontend/src/SelectGenebankStep.tsx
@@ -10,6 +10,7 @@ interface SelectGenebankStepProps {
   genebankName: string | null;
   setGenebankName: (name: string) => void;
   onUpdateStatus?: (status: string) => void;
+  handleNext?: () => void;
 }
 
 export const SelectGenebankStep: React.FC<SelectGenebankStepProps> = ({
@@ -17,12 +18,14 @@ export const SelectGenebankStep: React.FC<SelectGenebankStepProps> = ({
   genebankName,
   setGenebankName,
   onUpdateStatus,
+  handleNext,
 }) => {
   const { genebanks } = useDataContext();
 
   const handleGenebankSelect = (name: string) => {
     setGenebankName(name);
     onUpdateStatus?.("completed");
+    handleNext?.();
   };
 
   const availableGenebanks = genebanks.filter((g: any) => {

--- a/frontend/src/SelectHerdStep.tsx
+++ b/frontend/src/SelectHerdStep.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   Typography,
   TextField,
-  Link,
   Dialog,
   IconButton,
 } from "@material-ui/core";
@@ -14,10 +13,8 @@ import { BreedingForm } from "./breeding_form";
 import { useBreedingContext } from "./breeding_context";
 import { useDataContext } from "@app/data_context";
 import { useMessageContext } from "@app/message_context";
-import { useUserContext } from "@app/user_context";
 import { get } from "@app/communication";
-import { ExtendedBreeding, Breeding } from "./data_context_global";
-import { VariantType } from "notistack";
+import { ExtendedBreeding } from "./data_context_global";
 
 interface SelectHerdStepProps {
   user: any;
@@ -67,7 +64,6 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
   const [isBreedingDialogOpen, setIsBreedingDialogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  // Define all callback functions first
   const handleHerdSelect = useCallback(
     (id: string) => {
       setHerdId(id);
@@ -145,12 +141,10 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
     fetchBreedings();
   }, [fetchBreedings]);
 
-  // Then define effects
   useEffect(() => {
     if (!genebanks.length || !user) return;
 
     if (user.is_admin) {
-      // For admins, show all herds in the selected genebank
       if (genebankName) {
         const foundGenebank = genebanks.find(
           (g: any) => g.name === genebankName
@@ -160,7 +154,6 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
         }
       }
     } else if (user.is_manager?.length > 0) {
-      // For managers, show herds they manage in the selected genebank
       if (genebankName) {
         const foundGenebank = genebanks.find(
           (g: any) => g.name === genebankName
@@ -170,14 +163,12 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
         }
       }
     } else {
-      // For regular users, only show their owned herds
       if (user.is_owner && user.is_owner.length > 0) {
         const filteredHerds = genebanks.flatMap((g: any) =>
           g.herds.filter((herd: any) => user.is_owner.includes(herd.herd))
         );
         setHerdOptions(filteredHerds);
 
-        // Auto-select if user has only one herd
         if (filteredHerds.length === 1 && !herdId) {
           handleHerdSelect(filteredHerds[0].herd);
           onUpdateStatus?.("completed");
@@ -186,18 +177,15 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
     }
   }, [genebanks, user, herdId, handleHerdSelect, onUpdateStatus, genebankName]);
 
-  // Fetch breedings when herdId changes
   useEffect(() => {
     if (!herdId || isLoading) {
       setHerdBreedings([]);
       return;
     }
 
-    // Only fetch if we have a valid herdId and we're not already loading
     fetchBreedings();
-  }, [herdId]); // Only depend on herdId changes
+  }, [herdId]);
 
-  // Get filtered breedings for the report year
   const selectedHerdBreedings = useMemo(() => {
     if (!herdBreedings?.length || !reportYear) return herdBreedings || [];
 
@@ -205,7 +193,6 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
       .filter((breeding) => {
         if (!breeding) return false;
 
-        // If we have a birth_date in the report year, include it
         if (breeding.birth_date) {
           const birthYear = new Date(breeding.birth_date).getFullYear();
           if (birthYear === reportYear) {
@@ -213,13 +200,11 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
           }
         }
 
-        // Check breed_date regardless of whether we have a birth_date
         if (breeding.breed_date) {
           const breedDate = new Date(breeding.breed_date);
           const breedYear = breedDate.getFullYear();
 
           if (breedYear === reportYear) {
-            // Exclude if it's in the last 30 days of the year
             const yearEnd = new Date(reportYear, 11, 31);
             const daysBefore = Math.floor(
               (yearEnd.getTime() - breedDate.getTime()) / (1000 * 60 * 60 * 24)
@@ -236,7 +221,6 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
       }));
   }, [herdBreedings, reportYear]);
 
-  // Filter herds based on search term
   const filteredHerds = useMemo(() => {
     if (!searchTerm) return herdOptions;
     const search = searchTerm.toLowerCase();
@@ -247,7 +231,6 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
     });
   }, [herdOptions, searchTerm]);
 
-  // Helper function to determine if a row should be highlighted
   const getRowStyle = useCallback((breeding: any) => {
     if (!breeding.birth_date || breeding.litter_size6w == null) {
       return { backgroundColor: "#ffebee" };
@@ -258,7 +241,6 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
     return {};
   }, []);
 
-  // Helper function to render the info card
   const renderInfoCard = (selectedHerdId: string) => (
     <div
       className="yearlyReportCard"
@@ -301,231 +283,223 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
     </div>
   );
 
-  // Helper function to render the breeding list table
-  const renderBreedingTable = () => {
-    return (
-      <div>
-        {selectedHerdBreedings.length === 0 && reportYear && (
-          <div
-            className="yearlyReportCard"
-            style={{
-              marginTop: "2em",
-              padding: "1em",
-              border: "1px solid #ccc",
-              borderRadius: "8px",
-              backgroundColor: "#fff3e0",
-            }}
-          >
-            <Typography variant="body1" color="textSecondary" gutterBottom>
-              Inga kullar registrerade för år: {reportYear}. Vänlig lägg till
-              rapportårets alla kullar, det är dock OK att gå vidare om du inte
-              har tagit några kullar iår.
-            </Typography>
-            <div style={{ marginTop: "1em", textAlign: "right" }}>
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleNewBreedingClick}
-                startIcon={<EditIcon />}
-              >
-                Lägg till ny kull
-              </Button>
-            </div>
-          </div>
-        )}
-        {selectedHerdBreedings.length > 0 && (
-          <div
-            className="yearlyReportCard"
-            style={{
-              marginTop: "2em",
-              padding: "1em",
-              border: "1px solid #ccc",
-              borderRadius: "8px",
-            }}
-          >
-            <Typography variant="h6" gutterBottom>
-              Registrerade kullar för år: {reportYear}
-            </Typography>
-            <Typography
-              variant="subtitle1"
-              style={{
-                marginBottom: "1em",
-                padding: "1em",
-                backgroundColor: "#fff3e0",
-                border: "1px solid #ffb74d",
-                borderRadius: "4px",
-              }}
-            >
-              OBS! Kontrollera noga att alla kullar för {reportYear} är korrekt
-              registrerade. Detta är viktigt för årsrapportens kvalitet. Om
-              någon kull saknas eller är felaktig, vänligen korrigera detta
-              innan du fortsätter med årsrapporten.
-            </Typography>
-            <table style={{ width: "100%", borderCollapse: "collapse" }}>
-              <thead>
-                <tr>
-                  <th
-                    style={{
-                      border: "1px solid #ddd",
-                      padding: "8px",
-                      width: "40px",
-                    }}
-                  >
-                    Nr
-                  </th>
-                  <th style={{ border: "1px solid #ddd", padding: "8px" }}>
-                    Födelsedatum
-                  </th>
-                  <th style={{ border: "1px solid #ddd", padding: "8px" }}>
-                    Moder
-                  </th>
-                  <th style={{ border: "1px solid #ddd", padding: "8px" }}>
-                    Fader
-                  </th>
-                  <th
-                    style={{
-                      border: "1px solid #ddd",
-                      padding: "8px",
-                      width: "80px",
-                    }}
-                  >
-                    Antal Ungar
-                  </th>
-                  <th
-                    style={{
-                      border: "1px solid #ddd",
-                      padding: "8px",
-                      width: "80px",
-                    }}
-                  >
-                    Levande efter 6v
-                  </th>
-                  <th
-                    style={{
-                      border: "1px solid #ddd",
-                      padding: "8px",
-                      width: "50px",
-                    }}
-                  ></th>
-                </tr>
-              </thead>
-              <tbody>
-                {selectedHerdBreedings.map((breeding) => (
-                  <tr key={breeding.id} style={getRowStyle(breeding)}>
-                    <td
-                      style={{
-                        border: "1px solid #ddd",
-                        padding: "8px",
-                        textAlign: "center",
-                      }}
-                    >
-                      {breeding.number}
-                    </td>
-                    <td style={{ border: "1px solid #ddd", padding: "8px" }}>
-                      {breeding.birth_date}
-                    </td>
-                    <td style={{ border: "1px solid #ddd", padding: "8px" }}>
-                      {breeding.mother_name}
-                    </td>
-                    <td style={{ border: "1px solid #ddd", padding: "8px" }}>
-                      {breeding.father_name}
-                    </td>
-                    <td
-                      style={{
-                        border: "1px solid #ddd",
-                        padding: "8px",
-                        textAlign: "center",
-                      }}
-                    >
-                      {breeding.litter_size}
-                    </td>
-                    <td
-                      style={{
-                        border: "1px solid #ddd",
-                        padding: "8px",
-                        textAlign: "center",
-                      }}
-                    >
-                      {breeding.litter_size6w}
-                    </td>
-                    <td
-                      style={{
-                        border: "1px solid #ddd",
-                        padding: "8px",
-                        textAlign: "center",
-                      }}
-                    >
-                      <IconButton
-                        size="small"
-                        onClick={() => handleBreedingClick(breeding)}
-                        title="Redigera"
-                      >
-                        <EditIcon fontSize="small" />
-                      </IconButton>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            <div style={{ marginTop: "1em", textAlign: "right" }}>
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleNewBreedingClick}
-                startIcon={<EditIcon />}
-              >
-                Lägg till ny kull
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Breeding Edit Dialog */}
-        <Dialog
-          open={isBreedingDialogOpen}
-          onClose={handleBreedingDialogClose}
-          maxWidth="md"
-          fullWidth
+  const renderBreedingTable = () => (
+    <div>
+      {selectedHerdBreedings.length === 0 && reportYear && (
+        <div
+          className="yearlyReportCard"
+          style={{
+            marginTop: "2em",
+            padding: "1em",
+            border: "1px solid #ccc",
+            borderRadius: "8px",
+            backgroundColor: "#fff3e0",
+          }}
         >
-          <div style={{ position: "relative", padding: "1em" }}>
+          <Typography variant="body1" color="textSecondary" gutterBottom>
+            Inga kullar registrerade för år: {reportYear}. Vänlig lägg till
+            rapportårets alla kullar, det är dock OK att gå vidare om du inte
+            har tagit några kullar iår.
+          </Typography>
+          <div style={{ marginTop: "1em", textAlign: "right" }}>
             <Button
-              style={{
-                position: "absolute",
-                right: "8px",
-                top: "8px",
-                zIndex: 1,
-              }}
-              onClick={handleBreedingDialogClose}
+              variant="contained"
+              color="primary"
+              onClick={handleNewBreedingClick}
+              startIcon={<EditIcon />}
             >
-              Stäng
+              Lägg till ny kull
             </Button>
-            {selectedBreeding && (
-              <BreedingForm
-                data={selectedBreeding}
-                herdId={herdId || undefined}
-                handleBreedingsChanged={(shouldClose?: boolean) => {
-                  // Refresh the data first
-                  fetchBreedings();
-                  // Close if explicitly told to do so by the form
-                  if (shouldClose) {
-                    handleBreedingDialogClose();
-                  }
-                }}
-                handleActive={() => {}}
-              />
-            )}
           </div>
-        </Dialog>
-      </div>
-    );
-  };
+        </div>
+      )}
+      {selectedHerdBreedings.length > 0 && (
+        <div
+          className="yearlyReportCard"
+          style={{
+            marginTop: "2em",
+            padding: "1em",
+            border: "1px solid #ccc",
+            borderRadius: "8px",
+          }}
+        >
+          <Typography variant="h6" gutterBottom>
+            Registrerade kullar för år: {reportYear}
+          </Typography>
+          <Typography
+            variant="subtitle1"
+            style={{
+              marginBottom: "1em",
+              padding: "1em",
+              backgroundColor: "#fff3e0",
+              border: "1px solid #ffb74d",
+              borderRadius: "4px",
+            }}
+          >
+            OBS! Kontrollera noga att alla kullar för {reportYear} är korrekt
+            registrerade. Detta är viktigt för årsrapportens kvalitet. Om någon
+            kull saknas eller är felaktig, vänligen korrigera detta innan du
+            fortsätter med årsrapporten.
+          </Typography>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr>
+                <th
+                  style={{
+                    border: "1px solid #ddd",
+                    padding: "8px",
+                    width: "40px",
+                  }}
+                >
+                  Nr
+                </th>
+                <th style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  Födelsedatum
+                </th>
+                <th style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  Moder
+                </th>
+                <th style={{ border: "1px solid #ddd", padding: "8px" }}>
+                  Fader
+                </th>
+                <th
+                  style={{
+                    border: "1px solid #ddd",
+                    padding: "8px",
+                    width: "80px",
+                  }}
+                >
+                  Antal Ungar
+                </th>
+                <th
+                  style={{
+                    border: "1px solid #ddd",
+                    padding: "8px",
+                    width: "80px",
+                  }}
+                >
+                  Levande efter 6v
+                </th>
+                <th
+                  style={{
+                    border: "1px solid #ddd",
+                    padding: "8px",
+                    width: "50px",
+                  }}
+                ></th>
+              </tr>
+            </thead>
+            <tbody>
+              {selectedHerdBreedings.map((breeding) => (
+                <tr key={breeding.id} style={getRowStyle(breeding)}>
+                  <td
+                    style={{
+                      border: "1px solid #ddd",
+                      padding: "8px",
+                      textAlign: "center",
+                    }}
+                  >
+                    {breeding.number}
+                  </td>
+                  <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                    {breeding.birth_date}
+                  </td>
+                  <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                    {breeding.mother_name}
+                  </td>
+                  <td style={{ border: "1px solid #ddd", padding: "8px" }}>
+                    {breeding.father_name}
+                  </td>
+                  <td
+                    style={{
+                      border: "1px solid #ddd",
+                      padding: "8px",
+                      textAlign: "center",
+                    }}
+                  >
+                    {breeding.litter_size}
+                  </td>
+                  <td
+                    style={{
+                      border: "1px solid #ddd",
+                      padding: "8px",
+                      textAlign: "center",
+                    }}
+                  >
+                    {breeding.litter_size6w}
+                  </td>
+                  <td
+                    style={{
+                      border: "1px solid #ddd",
+                      padding: "8px",
+                      textAlign: "center",
+                    }}
+                  >
+                    <IconButton
+                      size="small"
+                      onClick={() => handleBreedingClick(breeding)}
+                      title="Redigera"
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div style={{ marginTop: "1em", textAlign: "right" }}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleNewBreedingClick}
+              startIcon={<EditIcon />}
+            >
+              Lägg till ny kull
+            </Button>
+          </div>
+        </div>
+      )}
 
-  // Render logic
+      <Dialog
+        open={isBreedingDialogOpen}
+        onClose={handleBreedingDialogClose}
+        maxWidth="md"
+        fullWidth
+      >
+        <div style={{ position: "relative", padding: "1em" }}>
+          <Button
+            style={{
+              position: "absolute",
+              right: "8px",
+              top: "8px",
+              zIndex: 1,
+            }}
+            onClick={handleBreedingDialogClose}
+          >
+            Stäng
+          </Button>
+          {selectedBreeding && (
+            <BreedingForm
+              data={selectedBreeding}
+              herdId={herdId || undefined}
+              handleBreedingsChanged={(shouldClose?: boolean) => {
+                fetchBreedings();
+                if (shouldClose) {
+                  handleBreedingDialogClose();
+                }
+              }}
+              handleActive={() => {}}
+            />
+          )}
+        </div>
+      </Dialog>
+    </div>
+  );
+
   if (!genebankName && (!user?.is_owner || user.is_owner.length === 0)) {
     return <Typography>Du äger ingen besättning.</Typography>;
   }
 
-  // Skip rendering selection UI if user has only one herd and is not admin/manager
   if (
     user?.is_owner?.length === 1 &&
     !user.is_admin &&
@@ -544,7 +518,6 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
       className="yearly-report-container"
       style={{ width: "100%", maxWidth: "1200px", margin: "0 auto" }}
     >
-      {/* Display info card if user has only one herd OR has selected a herd */}
       {(!genebankName &&
         user?.is_owner &&
         user.is_owner.length === 1 &&
@@ -558,7 +531,6 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
           {renderBreedingTable()}
         </div>
       ) : (
-        /* Show selection UI for all users who can see multiple herds */
         <>
           <Typography variant="h6">Välj besättning för årsrapport:</Typography>
           <TextField

--- a/frontend/src/SelectHerdStep.tsx
+++ b/frontend/src/SelectHerdStep.tsx
@@ -55,33 +55,36 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
   onUpdateStatus,
 }): React.ReactElement => {
   const { genebanks } = useDataContext();
+  const { userMessage } = useMessageContext();
+  const breedingContext = useBreedingContext();
+
   const [herdOptions, setHerdOptions] = useState<any[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [herdBreedings, setHerdBreedings] = useState<ExtendedBreeding[]>([]);
-  const { userMessage } = useMessageContext();
   const [selectedBreeding, setSelectedBreeding] = useState<
     ExtendedBreeding | "new" | null
   >(null);
   const [isBreedingDialogOpen, setIsBreedingDialogOpen] = useState(false);
-  const breedingContext = useBreedingContext();
   const [isLoading, setIsLoading] = useState(false);
 
-  // Initialize herd options based on genebankName and user ownership
-  useEffect(() => {
-    if (genebankName) {
-      const foundGenebank = genebanks.find((g: any) => g.name === genebankName);
-      if (foundGenebank) {
-        setHerdOptions(foundGenebank.herds);
-      }
-    } else if (user?.is_owner && user.is_owner.length > 0) {
-      const filteredHerds = genebanks.flatMap((g: any) =>
-        g.herds.filter((herd: any) => user.is_owner.includes(herd.herd))
-      );
-      setHerdOptions(filteredHerds);
-    }
-  }, [genebankName, genebanks, user]);
+  // Define all callback functions first
+  const handleHerdSelect = useCallback(
+    (id: string) => {
+      setHerdId(id);
+    },
+    [setHerdId]
+  );
 
-  // Fetch breedings function
+  const handleBreedingClick = useCallback((breeding: ExtendedBreeding) => {
+    setSelectedBreeding(breeding);
+    setIsBreedingDialogOpen(true);
+  }, []);
+
+  const handleNewBreedingClick = useCallback(() => {
+    setSelectedBreeding("new");
+    setIsBreedingDialogOpen(true);
+  }, []);
+
   const fetchBreedings = useCallback(async () => {
     if (!herdId || isLoading) return;
 
@@ -96,7 +99,6 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
         return;
       }
 
-      // Sort breedings by birth_date ascending, then by id ascending
       const sortedBreedings = data.breedings.sort(
         (a: RawBreeding, b: RawBreeding) => {
           const dateA = new Date(a.birth_date || "9999-12-31");
@@ -107,7 +109,6 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
         }
       );
 
-      // Add numbering and ensure all properties are present
       const processedBreedings: ExtendedBreeding[] = sortedBreedings.map(
         (breeding: RawBreeding, index: number) => ({
           ...breeding,
@@ -138,39 +139,63 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
     }
   }, [herdId, isLoading, onUpdateStatus, userMessage]);
 
-  // Fetch breedings when herdId changes
-  useEffect(() => {
-    if (!herdId) {
-      setHerdBreedings([]);
-      onUpdateStatus?.("error");
-      return;
-    }
-
-    fetchBreedings();
-  }, [herdId]);
-
-  const handleHerdSelect = useCallback(
-    (id: string) => {
-      setHerdId(id);
-    },
-    [setHerdId]
-  );
-
-  const handleBreedingClick = useCallback((breeding: ExtendedBreeding) => {
-    setSelectedBreeding(breeding);
-    setIsBreedingDialogOpen(true);
-  }, []);
-
-  const handleNewBreedingClick = useCallback(() => {
-    setSelectedBreeding("new");
-    setIsBreedingDialogOpen(true);
-  }, []);
-
   const handleBreedingDialogClose = useCallback(() => {
     setSelectedBreeding(null);
     setIsBreedingDialogOpen(false);
     fetchBreedings();
   }, [fetchBreedings]);
+
+  // Then define effects
+  useEffect(() => {
+    if (!genebanks.length || !user) return;
+
+    if (user.is_admin) {
+      // For admins, show all herds in the selected genebank
+      if (genebankName) {
+        const foundGenebank = genebanks.find(
+          (g: any) => g.name === genebankName
+        );
+        if (foundGenebank) {
+          setHerdOptions(foundGenebank.herds);
+        }
+      }
+    } else if (user.is_manager?.length > 0) {
+      // For managers, show herds they manage in the selected genebank
+      if (genebankName) {
+        const foundGenebank = genebanks.find(
+          (g: any) => g.name === genebankName
+        );
+        if (foundGenebank && user.is_manager.includes(foundGenebank.id)) {
+          setHerdOptions(foundGenebank.herds);
+        }
+      }
+    } else {
+      // For regular users, only show their owned herds
+      if (user.is_owner && user.is_owner.length > 0) {
+        const filteredHerds = genebanks.flatMap((g: any) =>
+          g.herds.filter((herd: any) => user.is_owner.includes(herd.herd))
+        );
+        setHerdOptions(filteredHerds);
+
+        // Auto-select if user has only one herd
+        if (filteredHerds.length === 1 && !herdId) {
+          handleHerdSelect(filteredHerds[0].herd);
+          onUpdateStatus?.("completed");
+        }
+      }
+    }
+  }, [genebanks, user, herdId, handleHerdSelect, onUpdateStatus, genebankName]);
+
+  // Fetch breedings when herdId changes
+  useEffect(() => {
+    if (!herdId || isLoading) {
+      setHerdBreedings([]);
+      return;
+    }
+
+    // Only fetch if we have a valid herdId and we're not already loading
+    fetchBreedings();
+  }, [herdId]); // Only depend on herdId changes
 
   // Get filtered breedings for the report year
   const selectedHerdBreedings = useMemo(() => {
@@ -232,10 +257,6 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
     }
     return {};
   }, []);
-
-  if (!genebankName && (!user?.is_owner || user.is_owner.length === 0)) {
-    return <Typography>Du äger ingen besättning.</Typography>;
-  }
 
   // Helper function to render the info card
   const renderInfoCard = (selectedHerdId: string) => (
@@ -499,6 +520,25 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
     );
   };
 
+  // Render logic
+  if (!genebankName && (!user?.is_owner || user.is_owner.length === 0)) {
+    return <Typography>Du äger ingen besättning.</Typography>;
+  }
+
+  // Skip rendering selection UI if user has only one herd and is not admin/manager
+  if (
+    user?.is_owner?.length === 1 &&
+    !user.is_admin &&
+    (!user.is_manager || user.is_manager.length === 0)
+  ) {
+    return (
+      <div style={{ width: "100%" }}>
+        {renderInfoCard(user.is_owner[0])}
+        {renderBreedingTable()}
+      </div>
+    );
+  }
+
   return (
     <div
       className="yearly-report-container"
@@ -518,34 +558,32 @@ export const SelectHerdStep: React.FC<SelectHerdStepProps> = ({
           {renderBreedingTable()}
         </div>
       ) : (
-        /* Multiple Herds or Genebank Users - Selection UI */
-        (genebankName || (user?.is_owner && user.is_owner.length > 1)) && (
-          <>
-            <Typography variant="h6">
-              Välj besättning för årsrapport:
-            </Typography>
-            <TextField
-              label="Sök besättning"
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              fullWidth
-              margin="normal"
-            />
-            <div style={{ maxHeight: "300px", overflowY: "auto" }}>
-              {filteredHerds.map((herd: any) => (
-                <Button
-                  key={herd.herd}
-                  variant={herd.herd === herdId ? "contained" : "outlined"}
-                  color={herd.herd === herdId ? "primary" : "default"}
-                  onClick={() => handleHerdSelect(herd.herd)}
-                  style={{ margin: "0.5em" }}
-                >
-                  {herd.herd_name || herd.herd}
-                </Button>
-              ))}
-            </div>
-          </>
-        )
+        /* Show selection UI for all users who can see multiple herds */
+        <>
+          <Typography variant="h6">Välj besättning för årsrapport:</Typography>
+          <TextField
+            label="Sök besättning"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+          <div style={{ maxHeight: "300px", overflowY: "auto" }}>
+            {filteredHerds.map((herd: any) => (
+              <Button
+                key={herd.herd}
+                variant={herd.herd === herdId ? "contained" : "outlined"}
+                color={herd.herd === herdId ? "primary" : "default"}
+                onClick={() => handleHerdSelect(herd.herd)}
+                style={{ margin: "0.5em" }}
+              >
+                {herd.herd_name
+                  ? `${herd.herd} - ${herd.herd_name}`
+                  : herd.herd}
+              </Button>
+            ))}
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/src/YearlyReportForm.tsx
+++ b/frontend/src/YearlyReportForm.tsx
@@ -114,19 +114,13 @@ const YearlyReportForm: React.FC<YearlyReportFormProps> = ({
   ): ReportValues => {
     // Start with default values
     const values: ReportValues = {
+      // User-editable fields - can come from existing data
       genebankNumber: herdData.herd || "",
       breed: herdData.breed || "",
       gotlandskanin: herdData.genebank === 1,
       mellerudskanin: herdData.genebank === 2,
       breedingYear: reportYear || new Date().getFullYear(),
       endingGenbank: existingData?.endingGenbank || false,
-      numberOfLitters: 0,
-      totalBorn: 0,
-      totalAliveAfterSixWeeks: 0,
-      numberOfFemalesUsedInBreeding: 0,
-      numberOfMalesUsedInBreeding: 0,
-      numberOfFemalesWithCertificate: 0,
-      numberOfMalesWithCertificate: 0,
       allowPublication: existingData?.allowPublication || [],
       eligibleForSupport: existingData?.eligibleForSupport || false,
       notEligibleForSupport: existingData?.notEligibleForSupport || false,
@@ -150,6 +144,14 @@ const YearlyReportForm: React.FC<YearlyReportFormProps> = ({
           age: "",
         },
       },
+      // Computed fields - always start at 0, will be calculated below
+      numberOfLitters: 0,
+      totalBorn: 0,
+      totalAliveAfterSixWeeks: 0,
+      numberOfFemalesUsedInBreeding: 0,
+      numberOfMalesUsedInBreeding: 0,
+      numberOfFemalesWithCertificate: 0,
+      numberOfMalesWithCertificate: 0,
     };
 
     // Calculate values based on current herd data
@@ -193,8 +195,6 @@ const YearlyReportForm: React.FC<YearlyReportFormProps> = ({
     );
     values.numberOfFemalesUsedInBreeding = uniqueMothers.size;
     values.numberOfMalesUsedInBreeding = uniqueFathers.size;
-    values.numberOfFemalesWithCertificate = femaleRabbits.length;
-    values.numberOfMalesWithCertificate = maleRabbits.length;
 
     return values;
   };
@@ -220,18 +220,30 @@ const YearlyReportForm: React.FC<YearlyReportFormProps> = ({
           reportYear || new Date().getFullYear()
         } ${herdResponse.herd} ${herdName}`;
 
-        // Recalculate all computed values before submitting
-        const computedValues = calculateInitialValues(herdResponse, null);
         const payload = {
           data: {
-            ...values,
-            ...computedValues,
-            // Only include user-editable fields from values
+            // Use the values from the form - they are already correctly calculated
+            // and are read-only in the form
+            numberOfLitters: values.numberOfLitters,
+            totalBorn: values.totalBorn,
+            totalAliveAfterSixWeeks: values.totalAliveAfterSixWeeks,
+            numberOfFemalesUsedInBreeding: values.numberOfFemalesUsedInBreeding,
+            numberOfMalesUsedInBreeding: values.numberOfMalesUsedInBreeding,
+            numberOfFemalesWithCertificate:
+              values.numberOfFemalesWithCertificate,
+            numberOfMalesWithCertificate: values.numberOfMalesWithCertificate,
+            // User-editable fields
             allowPublication: values.allowPublication,
             diseases: values.diseases,
             defectsMalformations: values.defectsMalformations,
             endingGenbank: values.endingGenbank,
             eligibleForSupport: values.eligibleForSupport,
+            // Other required fields
+            genebankNumber: values.genebankNumber,
+            breed: values.breed,
+            gotlandskanin: values.gotlandskanin,
+            mellerudskanin: values.mellerudskanin,
+            breedingYear: values.breedingYear,
           },
           name: reportName,
           version: "1.0",

--- a/frontend/src/YearlyReportForm.tsx
+++ b/frontend/src/YearlyReportForm.tsx
@@ -195,6 +195,8 @@ const YearlyReportForm: React.FC<YearlyReportFormProps> = ({
     );
     values.numberOfFemalesUsedInBreeding = uniqueMothers.size;
     values.numberOfMalesUsedInBreeding = uniqueFathers.size;
+    values.numberOfFemalesWithCertificate = femaleRabbits.length;
+    values.numberOfMalesWithCertificate = maleRabbits.length;
 
     return values;
   };

--- a/frontend/src/YearlyReportMultiStepForm.tsx
+++ b/frontend/src/YearlyReportMultiStepForm.tsx
@@ -62,17 +62,13 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
   });
 
   const { isManagerOrAdmin, isHerdContactUpdateStep } = useMemo(() => {
-    // Check if user is admin or manages the Gotlandskanin genebank
     const isSystemAdmin = user?.is_admin;
-    const managesGotlandskanin =
-      user?.is_manager && user.is_manager.includes(1); // Check if actually a manager
+    const isManager = user?.is_manager && user.is_manager.length > 0;
 
     return {
-      isManagerOrAdmin: isSystemAdmin || managesGotlandskanin,
+      isManagerOrAdmin: isSystemAdmin || isManager,
       isHerdContactUpdateStep:
-        isSystemAdmin || managesGotlandskanin
-          ? activeStep === 2
-          : activeStep === 1,
+        isSystemAdmin || isManager ? activeStep === 2 : activeStep === 1,
     };
   }, [user, activeStep]);
 
@@ -96,7 +92,6 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
   }, [user]);
 
   useEffect(() => {
-    // Update canProceed based on step status
     const currentStep = isManagerOrAdmin ? activeStep : activeStep + 1;
     switch (currentStep) {
       case 0:
@@ -115,13 +110,27 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
         setCanProceed(stepStatus.batchUpdate === "completed");
         break;
       case 4:
-        // For the final step, we should allow proceeding if we've reached this step
         setCanProceed(true);
         break;
       default:
         setCanProceed(true);
     }
   }, [activeStep, stepStatus, isManagerOrAdmin]);
+
+  useEffect(() => {
+    if (hasAutoSelected || !user) return;
+
+    if (!user.is_admin && (!user.is_manager || user.is_manager.length === 0)) {
+      setGenebankName("Gotlandskanin");
+      handleStepStatus("genebank", "completed");
+      setHasAutoSelected(true);
+
+      if (user.is_owner?.length === 1) {
+        setHerdId(user.is_owner[0]);
+        handleStepStatus("herd", "completed");
+      }
+    }
+  }, [user, hasAutoSelected]);
 
   const handleNext = () => {
     // Validation before moving to next step
@@ -140,6 +149,10 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
         return;
       }
     }
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  };
+
+  const handleAutoAdvance = () => {
     setActiveStep((prevActiveStep) => prevActiveStep + 1);
   };
 
@@ -235,30 +248,12 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
   };
 
   const getStepContent = (step: number) => {
-    console.log("Getting step content", {
-      step,
-      user: {
-        is_admin: user?.is_admin,
-        is_manager: user?.is_manager,
-        is_owner: user?.is_owner,
-      },
-      genebankName,
-      herdId,
-    });
-
-    // Wait for user data to be loaded
     if (!user) {
       return <div>Laddar...</div>;
     }
 
-    // For non-admin/non-manager users, skip genebank selection
-    const managesGotlandskanin = user.is_manager && user.is_manager.includes(1);
-    if (!user.is_admin && !managesGotlandskanin) {
-      console.log("Rendering regular user step", {
-        step,
-        genebankName,
-        herdId,
-      });
+    const isManager = user.is_manager && user.is_manager.length > 0;
+    if (!user.is_admin && !isManager) {
       switch (step) {
         case 0:
           return (
@@ -310,7 +305,6 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
       }
     }
 
-    // For admin/manager users, show all steps including genebank selection
     switch (step) {
       case 0:
         return (
@@ -319,6 +313,7 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
             genebankName={genebankName}
             setGenebankName={setGenebankName}
             onUpdateStatus={(status) => handleStepStatus("genebank", status)}
+            handleNext={handleAutoAdvance}
           />
         );
       case 1:
@@ -366,79 +361,6 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
         return <div>Okänt steg</div>;
     }
   };
-
-  // Initialize state when user data is loaded
-  useEffect(() => {
-    console.log("Auto-select effect", {
-      hasAutoSelected,
-      user: {
-        is_admin: user?.is_admin,
-        is_manager: user?.is_manager,
-        is_owner: user?.is_owner,
-      },
-      currentStep: activeStep,
-      genebankName,
-      herdId,
-    });
-
-    // Skip if we've already auto-selected or if user data isn't loaded yet
-    if (hasAutoSelected || !user) {
-      console.log("Skipping auto-select", {
-        hasAutoSelected,
-        user: !!user,
-      });
-      return;
-    }
-
-    // For non-admin/non-manager users, auto-select Gotlandskanin
-    if (!user.is_admin && (!user.is_manager || user.is_manager.length === 0)) {
-      console.log("Setting up for regular user");
-      setGenebankName("Gotlandskanin");
-      handleStepStatus("genebank", "completed");
-      setHasAutoSelected(true);
-
-      // If user has only one herd, auto-select it too
-      if (user.is_owner?.length === 1) {
-        console.log("Auto-selecting for single herd owner", {
-          herd: user.is_owner[0],
-          currentStep: activeStep,
-        });
-        setHerdId(user.is_owner[0]);
-        handleStepStatus("herd", "completed");
-      }
-    }
-  }, [user, activeStep, genebankName, herdId]);
-
-  // Track step status changes
-  useEffect(() => {
-    console.log("Step status update", {
-      stepStatus,
-      currentStep: activeStep,
-      isManagerOrAdmin:
-        user?.is_admin || (user?.is_manager && user.is_manager.length > 0),
-    });
-  }, [stepStatus, activeStep, user]);
-
-  // Debug logging
-  useEffect(() => {
-    console.log("YearlyReportMultiStepForm - State update", {
-      activeStep,
-      genebankName,
-      herdId,
-      selectedHerd,
-      selectedGenebank,
-      canProceed,
-      user: user?.is_owner,
-    });
-  }, [
-    activeStep,
-    genebankName,
-    herdId,
-    selectedHerd,
-    selectedGenebank,
-    canProceed,
-    user,
-  ]);
 
   return (
     <Paper style={{ padding: "2em" }}>

--- a/frontend/src/YearlyReportMultiStepForm.tsx
+++ b/frontend/src/YearlyReportMultiStepForm.tsx
@@ -41,6 +41,7 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
   const { user } = useUserContext();
   const { userMessage } = useMessageContext();
   const { loadData } = useDataContext();
+  const [hasAutoSelected, setHasAutoSelected] = useState(false);
 
   const [activeStep, setActiveStep] = useState(0);
   const [genebankName, setGenebankName] = useState<string | null>(null);
@@ -61,32 +62,38 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
   });
 
   const { isManagerOrAdmin, isHerdContactUpdateStep } = useMemo(() => {
-    const isAdmin =
-      user?.is_admin || (user?.is_manager ? user.is_manager.length > 0 : false);
+    // Check if user is admin or manages the Gotlandskanin genebank
+    const isSystemAdmin = user?.is_admin;
+    const managesGotlandskanin =
+      user?.is_manager && user.is_manager.includes(1); // Check if actually a manager
+
     return {
-      isManagerOrAdmin: isAdmin,
-      isHerdContactUpdateStep: isAdmin ? activeStep === 2 : activeStep === 1,
+      isManagerOrAdmin: isSystemAdmin || managesGotlandskanin,
+      isHerdContactUpdateStep:
+        isSystemAdmin || managesGotlandskanin
+          ? activeStep === 2
+          : activeStep === 1,
     };
   }, [user, activeStep]);
 
-  const steps = useMemo(
-    () =>
-      isManagerOrAdmin
-        ? [
-            "Välj Genbank",
-            "Välj Besättning",
-            "Uppdatera Kontaktinformation",
-            "Uppdatera Kaniner",
-            "Årsrapport",
-          ]
-        : [
-            "Välj Besättning",
-            "Uppdatera Kontaktinformation",
-            "Uppdatera Kaniner",
-            "Årsrapport",
-          ],
-    [isManagerOrAdmin]
-  );
+  const steps = useMemo(() => {
+    if (!user) return [];
+
+    return user.is_admin || (user.is_manager && user.is_manager.length > 0)
+      ? [
+          "Välj Genbank",
+          "Välj Besättning",
+          "Uppdatera Kontaktinformation",
+          "Uppdatera Kaniner",
+          "Årsrapport",
+        ]
+      : [
+          "Välj Besättning",
+          "Uppdatera Kontaktinformation",
+          "Uppdatera Kaniner",
+          "Årsrapport",
+        ];
+  }, [user]);
 
   useEffect(() => {
     // Update canProceed based on step status
@@ -228,72 +235,36 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
   };
 
   const getStepContent = (step: number) => {
-    if (isManagerOrAdmin) {
-      switch (step) {
-        case 0:
-          return (
-            <SelectGenebankStep
-              user={user}
-              genebankName={genebankName}
-              setGenebankName={setGenebankName}
-              onUpdateStatus={(status) => handleStepStatus("genebank", status)}
-            />
-          );
-        case 1:
-          return (
-            <SelectHerdStep
-              user={user}
-              genebankName={genebankName}
-              herdId={herdId}
-              setHerdId={setHerdId}
-              reportYear={reportYear}
-              onUpdateStatus={(status) => handleStepStatus("herd", status)}
-            />
-          );
-        case 2:
-          return (
-            <HerdContactUpdateStep
-              herdData={herdData}
-              herdId={herdId}
-              loadData={loadData}
-              onUpdateStatus={(status) =>
-                handleStepStatus("herdContact", status)
-              }
-            />
-          );
-        case 3:
-          return (
-            <BatchRabbitUpdateStep
-              herdId={herdId}
-              reportYear={reportYear}
-              reportRoundId={reportRoundId}
-              onUpdateStatus={(status) =>
-                handleStepStatus("batchUpdate", status)
-              }
-            />
-          );
-        case 4:
-          return (
-            <YearlyReportStep
-              herdId={herdId}
-              reportRoundId={reportRoundId}
-              reportYear={reportYear}
-              onUpdateStatus={(status) =>
-                handleStepStatus("yearlyReport", status)
-              }
-              formRef={yearlyReportRef}
-            />
-          );
-        default:
-          return <div>Okänt steg</div>;
-      }
-    } else {
+    console.log("Getting step content", {
+      step,
+      user: {
+        is_admin: user?.is_admin,
+        is_manager: user?.is_manager,
+        is_owner: user?.is_owner,
+      },
+      genebankName,
+      herdId,
+    });
+
+    // Wait for user data to be loaded
+    if (!user) {
+      return <div>Laddar...</div>;
+    }
+
+    // For non-admin/non-manager users, skip genebank selection
+    const managesGotlandskanin = user.is_manager && user.is_manager.includes(1);
+    if (!user.is_admin && !managesGotlandskanin) {
+      console.log("Rendering regular user step", {
+        step,
+        genebankName,
+        herdId,
+      });
       switch (step) {
         case 0:
           return (
             <SelectHerdStep
               user={user}
-              genebankName={genebankName}
+              genebankName="Gotlandskanin"
               herdId={herdId}
               setHerdId={setHerdId}
               reportYear={reportYear}
@@ -338,7 +309,136 @@ const YearlyReportMultiStepForm: React.FC<Props> = ({
           return <div>Okänt steg</div>;
       }
     }
+
+    // For admin/manager users, show all steps including genebank selection
+    switch (step) {
+      case 0:
+        return (
+          <SelectGenebankStep
+            user={user}
+            genebankName={genebankName}
+            setGenebankName={setGenebankName}
+            onUpdateStatus={(status) => handleStepStatus("genebank", status)}
+          />
+        );
+      case 1:
+        return (
+          <SelectHerdStep
+            user={user}
+            genebankName={genebankName}
+            herdId={herdId}
+            setHerdId={setHerdId}
+            reportYear={reportYear}
+            onUpdateStatus={(status) => handleStepStatus("herd", status)}
+          />
+        );
+      case 2:
+        return (
+          <HerdContactUpdateStep
+            herdData={herdData}
+            herdId={herdId}
+            loadData={loadData}
+            onUpdateStatus={(status) => handleStepStatus("herdContact", status)}
+          />
+        );
+      case 3:
+        return (
+          <BatchRabbitUpdateStep
+            herdId={herdId}
+            reportYear={reportYear}
+            reportRoundId={reportRoundId}
+            onUpdateStatus={(status) => handleStepStatus("batchUpdate", status)}
+          />
+        );
+      case 4:
+        return (
+          <YearlyReportStep
+            herdId={herdId}
+            reportRoundId={reportRoundId}
+            reportYear={reportYear}
+            onUpdateStatus={(status) =>
+              handleStepStatus("yearlyReport", status)
+            }
+            formRef={yearlyReportRef}
+          />
+        );
+      default:
+        return <div>Okänt steg</div>;
+    }
   };
+
+  // Initialize state when user data is loaded
+  useEffect(() => {
+    console.log("Auto-select effect", {
+      hasAutoSelected,
+      user: {
+        is_admin: user?.is_admin,
+        is_manager: user?.is_manager,
+        is_owner: user?.is_owner,
+      },
+      currentStep: activeStep,
+      genebankName,
+      herdId,
+    });
+
+    // Skip if we've already auto-selected or if user data isn't loaded yet
+    if (hasAutoSelected || !user) {
+      console.log("Skipping auto-select", {
+        hasAutoSelected,
+        user: !!user,
+      });
+      return;
+    }
+
+    // For non-admin/non-manager users, auto-select Gotlandskanin
+    if (!user.is_admin && (!user.is_manager || user.is_manager.length === 0)) {
+      console.log("Setting up for regular user");
+      setGenebankName("Gotlandskanin");
+      handleStepStatus("genebank", "completed");
+      setHasAutoSelected(true);
+
+      // If user has only one herd, auto-select it too
+      if (user.is_owner?.length === 1) {
+        console.log("Auto-selecting for single herd owner", {
+          herd: user.is_owner[0],
+          currentStep: activeStep,
+        });
+        setHerdId(user.is_owner[0]);
+        handleStepStatus("herd", "completed");
+      }
+    }
+  }, [user, activeStep, genebankName, herdId]);
+
+  // Track step status changes
+  useEffect(() => {
+    console.log("Step status update", {
+      stepStatus,
+      currentStep: activeStep,
+      isManagerOrAdmin:
+        user?.is_admin || (user?.is_manager && user.is_manager.length > 0),
+    });
+  }, [stepStatus, activeStep, user]);
+
+  // Debug logging
+  useEffect(() => {
+    console.log("YearlyReportMultiStepForm - State update", {
+      activeStep,
+      genebankName,
+      herdId,
+      selectedHerd,
+      selectedGenebank,
+      canProceed,
+      user: user?.is_owner,
+    });
+  }, [
+    activeStep,
+    genebankName,
+    herdId,
+    selectedHerd,
+    selectedGenebank,
+    canProceed,
+    user,
+  ]);
 
   return (
     <Paper style={{ padding: "2em" }}>

--- a/frontend/src/breeding_context.tsx
+++ b/frontend/src/breeding_context.tsx
@@ -244,7 +244,9 @@ export const WithBreedingContext = (props: { children: React.ReactNode }) => {
     if (!breeding.litter_size6w) {
       return Math.min(breedingUpdates.litter_size6w, 9);
     }
-    if (breeding.litter_size6w < breedingUpdates.litter_size6w) {
+    if (
+      Number(breeding.litter_size6w) < Number(breedingUpdates.litter_size6w)
+    ) {
       return (
         Math.min(breedingUpdates.litter_size6w, 9) -
         Math.min(breeding.litter_size6w, 9)

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -294,7 +294,7 @@ export function BreedingForm({
       return false;
     }
 
-    if (userInput?.litter_size6w > userInput?.litter_size) {
+    if (Number(userInput?.litter_size6w) > Number(userInput?.litter_size)) {
       userMessage(
         "Kullstorleken efter 6 veckor får inte vara större än kullstorleken vid födseln.",
         "warning"

--- a/frontend/src/breeding_form.tsx
+++ b/frontend/src/breeding_form.tsx
@@ -99,7 +99,7 @@ export function BreedingForm({
   const [formState, setFormState] = React.useState(
     emptyBreeding as ExtendedBreeding
   );
-  const [showBirthForm, setShowBirthForm] = React.useState(true);
+  const [showBirthForm, setShowBirthForm] = React.useState(false);
   let defaultDate = new Date();
   defaultDate.setFullYear(defaultDate.getFullYear() - 10);
   const [fromDate, setFromDate] = React.useState(defaultDate as Date);
@@ -206,16 +206,39 @@ export function BreedingForm({
   };
 
   const autoFillBreedDate = (dateString: string) => {
-    let breedDate: Date | number = new Date(dateString);
-    breedDate.setDate(breedDate.getDate() - 30);
-    const breedDateLocal = breedDate.toLocaleDateString(locale);
-    setFormField("breed_date", breedDateLocal);
+    try {
+      // Parse the birth date string (expecting YYYY-MM-DD format)
+      const [year, month, day] = dateString.split("-").map(Number);
+      if (isNaN(year) || isNaN(month) || isNaN(day)) {
+        return;
+      }
+
+      // Create date object (month is 0-based in JavaScript)
+      const birthDate = new Date(year, month - 1, day);
+      // Validate that we have a real date
+      if (isNaN(birthDate.getTime())) {
+        return;
+      }
+
+      const breedDate = new Date(birthDate);
+      breedDate.setDate(birthDate.getDate() - 30);
+
+      // Format as YYYY-MM-DD for API
+      const breedYear = breedDate.getFullYear();
+      const breedMonth = String(breedDate.getMonth() + 1).padStart(2, "0");
+      const breedDay = String(breedDate.getDate()).padStart(2, "0");
+      const formattedDate = `${breedYear}-${breedMonth}-${breedDay}`;
+
+      setFormField("breed_date", formattedDate);
+    } catch (error) {
+      console.error("Error calculating breed date:", error);
+    }
   };
 
   React.useEffect(() => {
     if (
-      formState.breed_date == null &&
-      typeof formState.birth_date == "string"
+      (!formState.breed_date || formState.breed_date === "") &&
+      formState.birth_date
     ) {
       autoFillBreedDate(formState.birth_date);
     }

--- a/frontend/src/communication.tsx
+++ b/frontend/src/communication.tsx
@@ -7,6 +7,7 @@ const credentials_policy = "same-origin";
 
 /**
  * Creates a GET request to the given `url`, and returns the reply as json.
+ * Returns null for 401 (unauthorized) responses to maintain backwards compatibility.
  *
  * @param url The target URL for the GET request
  */
@@ -19,6 +20,10 @@ export async function get(url: string) {
       "Content-Type": "application/json",
     },
   });
+  // Return null for 401 to maintain backwards compatibility with user auth checks
+  if (resp.status === 401) {
+    return null;
+  }
   return await resp.json();
 }
 

--- a/frontend/src/individual_add.tsx
+++ b/frontend/src/individual_add.tsx
@@ -416,7 +416,7 @@ export function IndividualAdd({
       );
       return false;
     }
-    if (individual.litter_size6w > individual.litter_size) {
+    if (Number(individual.litter_size6w) > Number(individual.litter_size)) {
       userMessage(
         "Kullstorleken efter 6 veckor får inte vara större än kullstorleken vid födseln.",
         "warning"

--- a/frontend/src/individual_breeding_form.tsx
+++ b/frontend/src/individual_breeding_form.tsx
@@ -267,7 +267,7 @@ export function IndividualBreedingForm({
 
     if (
       (userInput.birth_date, userInput.litter_size) !== null &&
-      !(userInput.litter_size > 0)
+      !(Number(userInput.litter_size) > 0)
     ) {
       userMessage("Ange en kullstorlek större än 0", "warning");
       return false;
@@ -365,7 +365,7 @@ export function IndividualBreedingForm({
       const newBirthData: Birth = {
         date: breeding.birth_date,
         litter_size: breeding.litter_size,
-        litter_size6w: breeding.litter_size,
+        litter_size6w: breeding.litter_size6w,
         notes: breeding.birth_notes !== "" ? breeding.birth_notes : undefined,
         id: newBreeding.breeding_id,
       };

--- a/frontend/src/user_context.tsx
+++ b/frontend/src/user_context.tsx
@@ -134,10 +134,15 @@ export function WithUserContext(props: { children: React.ReactNode }) {
     return false;
   }
 
-  function logout() {
-    let status = handleLogin(get("/api/logout"));
+  async function logout(): Promise<Result> {
+    try {
+      await get("/api/logout");
+    } catch (e) {
+      console.error(e);
+    }
+    setUser(null);
     loadData("none");
-    return status;
+    return "logged_out";
   }
 
   function on_mount() {


### PR DESCRIPTION
## What

Back-ports the **frontend-only** commits that were applied directly to `production` (to ship fixes faster) but never merged back to `develop`. Cherry-picked with \`-x\` for traceability.

Commits (chronological):
- \`5d60f7f\` Refactor BreedingForm date handling/state
- \`9c7b06e\` User role checks + herd selection (SelectGenebankStep/SelectHerdStep)
- \`940ba60\` SelectHerdStep clarity/functionality
- \`2313f4f\` SelectGenebankStep + YearlyReportMultiStepForm
- \`b2380ac\` YearlyReportForm: streamline initial values/payload
- \`b7a4e13\` YearlyReportForm: counts of females/males with certificates
- \`754aae7\` / \`e55a29c\` / \`be929a7\` Litter-size numeric validation (BreedingForm, BreedingContext, IndividualAdd, IndividualBreedingForm)
- \`64c4707\` Handle 401 responses in get() (new API compatibility)
- \`aa827f8\` Clear user state on logout

## Why

`develop` had diverged from `production` because hotfixes went to prod first. This restores frontend parity. All changes are under `frontend/` (verified — no backend files).

## Scope notes

- **Backend-only** production divergences (\`get_yearly_reports\`, \`add_herd\`, \`herd_yearly_report\` auth, CI/\`create_packages.yml\`/\`production.yml\`) are **intentionally excluded** — test runs the herdbook2 backend, so this repo's backend divergence is out of scope.
- The footer logo/layout fix is handled separately in #728/#729.
- ⚠️ The YearlyReportForm commits (\`b7a4e13\`/\`b2380ac\`) were authored alongside backend \`get_yearly_reports\` changes that are **not** included here — verify against whatever backend serves these forms.

## Next

Once merged, the standard develop → test-prod sync propagates these to test.gotlandskaninen.se.