### PR TITLE
ci(create-packages): build frontend before main to fix release image build

### DIFF
--- a/.github/workflows/create_packages.yml
+++ b/.github/workflows/create_packages.yml
@@ -92,21 +92,35 @@ jobs:
             echo "Tag detected - rebuilding frontend and main with version ${{ github.ref_name }}"
             # Pull production image for r-api
             docker pull "ghcr.io/nbisweden/herdbook_r-api:production"
-            # Build frontend and main with new version
+            # Build frontend and main with new version.
+            # Build frontend FIRST so main's `COPY --from=herdbook_frontend:latest`
+            # resolves the locally-built image instead of trying to pull it from a
+            # registry (building both in one `docker compose build` fails to resolve it).
             docker compose build --build-arg BUILDKIT_INLINE_CACHE=1 \
               --build-arg COMMIT_SHA="${{ github.sha }}" \
-              herdbook-frontend main
+              herdbook-frontend
+            docker compose build --build-arg BUILDKIT_INLINE_CACHE=1 \
+              --build-arg COMMIT_SHA="${{ github.sha }}" \
+              main
           elif [[ "${{ github.ref_name }}" == "production" ]]; then
             echo "Production branch - building fresh images"
+            # Build frontend FIRST so main can COPY --from the local image.
             docker compose build --no-cache --build-arg BUILDKIT_INLINE_CACHE=1 \
               --build-arg COMMIT_SHA="${{ github.sha }}" \
-              herdbook-frontend main
+              herdbook-frontend
+            docker compose build --no-cache --build-arg BUILDKIT_INLINE_CACHE=1 \
+              --build-arg COMMIT_SHA="${{ github.sha }}" \
+              main
           else
             # For other branches, only build changed images and their dependents
             if [[ "${{ needs.changes.outputs.frontend }}" == "true" ]]; then
+              # Build frontend FIRST so main can COPY --from the local image.
               docker compose build --build-arg BUILDKIT_INLINE_CACHE=1 \
                 --build-arg COMMIT_SHA="${{ github.sha }}" \
-                herdbook-frontend main
+                herdbook-frontend
+              docker compose build --build-arg BUILDKIT_INLINE_CACHE=1 \
+                --build-arg COMMIT_SHA="${{ github.sha }}" \
+                main
             elif [[ "${{ needs.changes.outputs.main }}" == "true" ]]; then
               docker compose build --build-arg BUILDKIT_INLINE_CACHE=1 \
                 --build-arg COMMIT_SHA="${{ github.sha }}" \


### PR DESCRIPTION
## Problem

The `Create packages` build fails on `v.*` tags (and would on `production`) with:

```
target main: failed to solve: herdbook_frontend:latest: failed to resolve source
metadata for docker.io/library/herdbook_frontend:latest: pull access denied
```

The build ran `docker compose build herdbook-frontend main` as a **single** command, so BuildKit handled both in one graph. `main`'s `.docker/main` does `COPY --from=herdbook_frontend:latest`, which BuildKit tried to resolve as a registry image (→ Docker Hub → access denied) **before** the frontend image was built locally.

## Fix

Build `herdbook-frontend` **first**, then `main`, in all three build paths (tag, production, changed-frontend). Once the frontend image exists locally as `herdbook_frontend:latest`, main's `COPY --from` resolves it from the local image store (verified locally — sequential builds succeed).

Workflow-only change; no app code touched.

## After merge

Re-point the `v.1.1.5` tag (or cut `v.1.1.6`) at `production` HEAD so the build re-runs with the fixed workflow — tag events use the workflow file from the tagged commit.