### PR TITLE
fix(docker): base main image on python:3.8-bullseye (Buster EOL)

### DIFF
--- a/.docker/main
+++ b/.docker/main
@@ -9,7 +9,7 @@ COPY --from=herdbook_frontend:latest --chown=node:node /home/node/node_modules/ 
 
 RUN npm run build
 
-FROM python:3.8-buster
+FROM python:3.8-bullseye
 ENV TZ='Europe/Stockholm'
 RUN mkdir -p /code
 


### PR DESCRIPTION
## Problem

After the build-ordering fix (#733), the release/production build gets further but now fails in `main`'s apt step:

```
Err:4 http://deb.debian.org/debian buster Release   404  Not Found
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
```

`.docker/main` is `FROM python:3.8-buster`. **Debian Buster is EOL** and its packages were removed from `deb.debian.org` (moved to `archive.debian.org`), so `apt-get update` 404s. The production path builds with `--no-cache`, so it can't fall back to cached apt layers — it fails every time. Not flaky.

## Fix

`FROM python:3.8-buster` → `FROM python:3.8-bullseye`. Bullseye's repos are live (supported into 2026) and all the apt packages (`supervisor nginx inotify-tools rsync swig python3-pykcs11`) exist there. **Python stays at 3.8**, so every pinned dependency in `app/requirements.txt` installs exactly as before — zero dependency risk.

### Why not bump to Python 3.13 / Bookworm (like the new system)?

The new system (`herdbook2`) moved its legacy backend to `python:3.13-bookworm`, but that required a **full `requirements.txt` rewrite** (Flask 2→3, Werkzeug 2→3, cryptography 41→46, + numpy/redis/gunicorn/Pillow/talisman/limiter, etc.). Redoing that overhaul on this retiring legacy repo is high-risk and out of scope for unblocking a release. Bullseye gets us off dead Buster with a one-line, behavior-neutral change.

## After merge

Re-point `v.1.1.5` (or cut `v.1.1.6`) at `production` HEAD so the release build re-runs with both this and #733.